### PR TITLE
[Feat] 에러 코드와 공통 예외 처리 구현

### DIFF
--- a/src/main/java/com/adit/global/error/ErrorResponse.java
+++ b/src/main/java/com/adit/global/error/ErrorResponse.java
@@ -1,0 +1,133 @@
+package com.adit.global.error;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+import com.adit.global.error.exception.GlobalErrorCode;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Global Exception Handler에서 발생한 에러에 대한 응답 처리를 관리
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+	private HttpStatus status;                 // 에러 상태 코드
+	private String code;        // 에러 구분 코드
+	private String resultMsg;           // 에러 메시지
+	private List<FieldError> errors;    // 상세 에러 메시지
+	private String reason;              // 에러 이유
+
+	/**
+	 * ErrorResponse 생성자-1
+	 *
+	 * @param code GlobalErrorCode
+	 */
+	@Builder
+	protected ErrorResponse(final GlobalErrorCode code) {
+		this.resultMsg = code.getMessage();
+		this.status = code.getHttpStatus();
+		this.code = code.getCode();
+		this.errors = new ArrayList<>();
+	}
+
+	/**
+	 * ErrorResponse 생성자-2
+	 *
+	 * @param code   GlobalErrorCode
+	 * @param reason String
+	 */
+	@Builder
+	protected ErrorResponse(final GlobalErrorCode code, final String reason) {
+		this.resultMsg = code.getMessage();
+		this.status = code.getHttpStatus();
+		this.code = code.getCode();
+		this.reason = reason;
+	}
+
+	/**
+	 * ErrorResponse 생성자-3
+	 *
+	 * @param code   GlobalErrorCode
+	 * @param errors List<FieldError>
+	 */
+	@Builder
+	protected ErrorResponse(final GlobalErrorCode code, final List<FieldError> errors) {
+		this.resultMsg = code.getMessage();
+		this.status = code.getHttpStatus();
+		this.errors = errors;
+		this.code = code.getCode();
+	}
+
+	/**
+	 * Global Exception 전송 타입-1
+	 *
+	 * @param code          GlobalErrorCode
+	 * @param bindingResult BindingResult
+	 * @return ErrorResponse
+	 */
+	public static ErrorResponse of(final GlobalErrorCode code, final BindingResult bindingResult) {
+		return new ErrorResponse(code, FieldError.of(bindingResult));
+	}
+
+	/**
+	 * Global Exception 전송 타입-2
+	 *
+	 * @param code GlobalErrorCode
+	 * @return ErrorResponse
+	 */
+	public static ErrorResponse of(final GlobalErrorCode code) {
+		return new ErrorResponse(code);
+	}
+
+	/**
+	 * Global Exception 전송 타입-3
+	 *
+	 * @param code   GlobalErrorCode
+	 * @param reason String
+	 * @return ErrorResponse
+	 */
+	public static ErrorResponse of(final GlobalErrorCode code, final String reason) {
+		return new ErrorResponse(code, reason);
+	}
+
+	/**
+	 * 에러를 e.getBindingResult() 형태로 전달 받는 경우 해당 내용을 상세 내용으로 변경하는 기능을 수행한다.
+	 */
+	@Getter
+	public static class FieldError {
+		private final String field;
+		private final String value;
+		private final String reason;
+
+		@Builder
+		FieldError(String field, String value, String reason) {
+			this.field = field;
+			this.value = value;
+			this.reason = reason;
+		}
+
+		public static List<FieldError> of(final String field, final String value, final String reason) {
+			List<FieldError> fieldErrors = new ArrayList<>();
+			fieldErrors.add(new FieldError(field, value, reason));
+			return fieldErrors;
+		}
+
+		private static List<FieldError> of(final BindingResult bindingResult) {
+			final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+			return fieldErrors.stream()
+				.map(error -> new FieldError(
+					error.getField(),
+					error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+					error.getDefaultMessage()))
+				.toList();
+		}
+	}
+}

--- a/src/main/java/com/adit/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/adit/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,160 @@
+package com.adit.global.error;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import com.adit.global.error.exception.GlobalErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Controller 내에서 발생하는 Exception 대해서 Catch 하여 응답값(Response)을 보내주는 기능을 수행함.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	private final static HttpStatus HTTP_STATUS_OK = HttpStatus.OK;
+	private final static HttpStatus HTTP_STATUS_BAD_REQUEST = HttpStatus.BAD_REQUEST;
+
+	/**
+	 * [Exception] API 호출 시 '객체' 혹은 '파라미터' 데이터 값이 유효하지 않은 경우
+	 *
+	 * @param ex MethodArgumentNotValidException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+		log.error("handleMethodArgumentNotValidException", ex);
+		BindingResult bindingResult = ex.getBindingResult();
+		StringBuilder stringBuilder = new StringBuilder();
+		for (FieldError fieldError : bindingResult.getFieldErrors()) {
+			stringBuilder.append(fieldError.getField()).append(":");
+			stringBuilder.append(fieldError.getDefaultMessage());
+			stringBuilder.append(", ");
+		}
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.NOT_VALID_ERROR, String.valueOf(stringBuilder));
+		return new ResponseEntity<>(response, HTTP_STATUS_OK);
+	}
+
+	/**
+	 * [Exception] API 호출 시 'Header' 내에 데이터 값이 유효하지 않은 경우
+	 *
+	 * @param ex MissingRequestHeaderException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(MissingRequestHeaderException.class)
+	protected ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
+		log.error("MissingRequestHeaderException", ex);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.REQUEST_BODY_MISSING_ERROR, ex.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_OK);
+	}
+
+	/**
+	 * [Exception] 클라이언트에서 Body로 '객체' 데이터가 넘어오지 않았을 경우
+	 *
+	 * @param ex HttpMessageNotReadableException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+		HttpMessageNotReadableException ex) {
+		log.error("HttpMessageNotReadableException", ex);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.REQUEST_BODY_MISSING_ERROR, ex.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_BAD_REQUEST);
+	}
+
+	/**
+	 * [Exception] 클라이언트에서 request로 '파라미터로' 데이터가 넘어오지 않았을 경우
+	 *
+	 * @param ex MissingServletRequestParameterException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	protected ResponseEntity<ErrorResponse> handleMissingRequestHeaderExceptionException(
+		MissingServletRequestParameterException ex) {
+		log.error("handleMissingServletRequestParameterException", ex);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.MISSING_REQUEST_PARAMETER_ERROR,
+			ex.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_BAD_REQUEST);
+	}
+
+	/**
+	 * [Exception] 잘못된 서버 요청일 경우 발생한 경우
+	 *
+	 * @param e HttpClientErrorException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(HttpClientErrorException.BadRequest.class)
+	protected ResponseEntity<ErrorResponse> handleBadRequestException(HttpClientErrorException e) {
+		log.error("HttpClientErrorException.BadRequest", e);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.BAD_REQUEST_ERROR, e.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_OK);
+	}
+
+	/**
+	 * [Exception] 잘못된 주소로 요청 한 경우
+	 *
+	 * @param e NoHandlerFoundException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(NoHandlerFoundException.class)
+	protected ResponseEntity<ErrorResponse> handleNoHandlerFoundExceptionException(NoHandlerFoundException e) {
+		log.error("handleNoHandlerFoundExceptionException", e);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.NOT_FOUND_ERROR, e.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_OK);
+	}
+
+	/**
+	 * [Exception] NULL 값이 발생한 경우
+	 *
+	 * @param e NullPointerException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(NullPointerException.class)
+	protected ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
+		log.error("handleNullPointerException", e);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.NULL_POINT_ERROR, e.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_OK);
+	}
+
+	/**
+	 * Input / Output 내에서 발생한 경우
+	 *
+	 * @param ex IOException
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(IOException.class)
+	protected ResponseEntity<ErrorResponse> handleIOException(IOException ex) {
+		log.error("handleIOException", ex);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.IO_ERROR, ex.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_OK);
+	}
+
+	// ==================================================================================================================
+
+	/**
+	 * [Exception] 모든 Exception 경우 발생
+	 *
+	 * @param ex Exception
+	 * @return ResponseEntity<ErrorResponse>
+	 */
+	@ExceptionHandler(Exception.class)
+	protected final ResponseEntity<ErrorResponse> handleAllExceptions(Exception ex) {
+		log.error("Exception", ex);
+		final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INTERNAL_SERVER_ERROR, ex.getMessage());
+		return new ResponseEntity<>(response, HTTP_STATUS_OK);
+	}
+}

--- a/src/main/java/com/adit/global/error/exception/BusinessException.java
+++ b/src/main/java/com/adit/global/error/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package com.adit.global.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+	private final GlobalErrorCode errorCode;
+
+	public BusinessException(String message, GlobalErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public BusinessException(GlobalErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public GlobalErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/adit/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/adit/global/error/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.adit.global.error.exception;
+
+import org.apache.http.HttpStatus;
+
+public interface ErrorCode {
+	String name();
+
+	HttpStatus getHttpStatus();
+
+	String getMessage();
+}

--- a/src/main/java/com/adit/global/error/exception/GlobalErrorCode.java
+++ b/src/main/java/com/adit/global/error/exception/GlobalErrorCode.java
@@ -1,0 +1,85 @@
+package com.adit.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * [공통 코드] API 통신에 대한 '에러 코드'를 Enum 형태로 관리를 한다.
+ * Global Error CodeList : 전역으로 발생하는 에러코드를 관리한다.
+ * Custom Error CodeList : 업무 페이지에서 발생하는 에러코드를 관리한다
+ * Error Code Constructor : 에러코드를 직접적으로 사용하기 위한 생성자를 구성한다.
+ *
+ * @author lee
+ */
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+	/**
+	 * ******************************* Global Error CodeList ***************************************
+	 * HTTP Status Code
+	 * 400 : Bad Request
+	 * 401 : Unauthorized
+	 * 403 : Forbidden
+	 * 404 : Not Found
+	 * 500 : Internal Server Error
+	 * *********************************************************************************************
+	 */
+	// 잘못된 요청
+	BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "G001", "Bad Request Exception"),
+
+	// @RequestBody 데이터 미 존재
+	REQUEST_BODY_MISSING_ERROR(HttpStatus.BAD_REQUEST, "G002", "Required request body is missing"),
+
+	// 유효하지 않은 타입
+	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "G003", " Invalid Type Value"),
+
+	// Request Parameter 로 데이터가 전달되지 않을 경우
+	MISSING_REQUEST_PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "G004", "Missing Servlet RequestParameter Exception"),
+
+	// 입력/출력 값이 유효하지 않음
+	IO_ERROR(HttpStatus.BAD_REQUEST, "G005", "I/O Exception"),
+
+	// 권한이 없음
+	FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "G008", "Forbidden Exception"),
+
+	// 서버로 요청한 리소스가 존재하지 않음
+	NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "G009", "Not Found Exception"),
+
+	// NULL Point Exception 발생
+	NULL_POINT_ERROR(HttpStatus.NOT_FOUND, "G010", "Null Point Exception"),
+
+	// @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
+	NOT_VALID_ERROR(HttpStatus.NOT_FOUND, "G011", "handle Validation Exception"),
+
+	// @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
+	NOT_VALID_HEADER_ERROR(HttpStatus.NOT_FOUND, "G012", "Header에 데이터가 존재하지 않는 경우 "),
+
+	// 서버가 처리 할 방법을 모르는 경우 발생
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G999", "Internal Server Error Exception"),
+
+	/**
+	 * ******************************* Custom Error CodeList ***************************************
+	 */
+	// Transaction Insert Error
+	INSERT_ERROR(HttpStatus.OK, "9999", "Insert Transaction Error Exception"),
+
+	// Transaction Update Error
+	UPDATE_ERROR(HttpStatus.OK, "9999", "Update Transaction Error Exception"),
+
+	// Transaction Delete Error
+	DELETE_ERROR(HttpStatus.OK, "9999", "Delete Transaction Error Exception");
+
+	// 에러 코드의 '코드 상태'을 반환한다.
+	private final HttpStatus httpStatus;
+
+	// 에러 코드의 '코드간 구분 값'을 반환한다.
+	private final String code;
+
+	// 에러 코드의 '코드 메시지'을 반환한다.
+	private final String message;
+}
+
+


### PR DESCRIPTION
## 💡 작업 내용

- [x] 에러 코드와 공통 예외 처리 구현

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

* HTTP 상태 코드와 에러 코드 표준화
* 일관된 예외 처리를 위한 공통 에러 핸들링 구현

**에러 코드 분류**
* 일반 에러 (G001-G999)
* 커스텀 에러 (9999)

**HTTP 상태 코드별 구분**

- `400`: 잘못된 요청 관련 에러
- `403`: 권한 관련 에러
- `404`: 리소스 미존재 에러
- `500`: 서버 내부 에러

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
