### PR TITLE
[fix] CI/CD 중단 오류 해결

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'  # Gradle 캐싱 추가
+          cache: 'gradle'
 
       - name: Create .env file
         run: |
@@ -39,21 +39,22 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: clean build -x test # 테스트 제외 옵션 추가
+          arguments: clean build -x test
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: AditServer
           path: build/libs/*.jar
-          retention-days: 1  # 아티팩트 보관 기간 설정
+          retention-days: 1
+          compression-level: 0
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: AditServer
           path: build/libs/
@@ -82,10 +83,8 @@ jobs:
           echo "$EC2_SSH_KEY" > private_key.pem
           chmod 600 private_key.pem
           
-          # .env 파일 전송
           scp -i private_key.pem -o StrictHostKeyChecking=no .env $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/.env
           
-          # JAR 파일 찾기 및 전송
           jar_file=$(find build/libs -name '*.jar' ! -name '*plain.jar' | head -n 1)
           if [ -z "$jar_file" ]; then
             echo "JAR file not found"
@@ -94,7 +93,6 @@ jobs:
           
           scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/AditServer.jar
           
-          # 애플리케이션 재시작
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USERNAME@$EC2_HOST "
             pid=\$(pgrep java || echo '')
             if [ ! -z \"\$pid\" ]; then


### PR DESCRIPTION


## 💡 작업 내용

- [x] actions/upload-artifact 및 download-artifact v3에서 v4로 업그레이드

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)
- Github Action의 `upload-artifact`와 `download-artifact` 버전이 업그레이드 되면서 기존의 v3는 지원을 종료하였기 때문에 v4로 버전을 업그레이드하여 workflow를 수정

## 📗 참고 자료 (선택)
[Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
