### PR TITLE
[Feat] JWT를 이용한 사용자 토큰 발급 구현 

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -27,6 +27,8 @@ jobs:
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
           echo "SPRING_AI_OPENAI_API_KEY=${{ secrets.SPRING_AI_OPENAI_API_KEY }}" >> .env
           echo "JWT_KEY=${{ secrets.JWT_KEY }}" >> .env
+          echo "JWT_ACCESS_TOKEN_EXPIRATION=${{ secrets.JWT_ACCESS_TOKEN_EXPIRATION }}" >> .env
+          echo "JWT_REFRESH_TOKEN_EXPIRATION=${{ secrets.JWT_REFRESH_TOKEN_EXPIRATION }}" >> .env
           echo "SERVER_BASE_URL=${{ secrets.SERVER_BASE_URL }}" >> .env
           echo "SCRAPER_API_TOKEN=${{ secrets.SCRAPER_API_TOKEN }}" >> .env
           echo "SCRAPER_BASE_URL=${{ secrets.SCRAPER_BASE_URL }}" >> .env
@@ -69,6 +71,8 @@ jobs:
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
           echo "SPRING_AI_OPENAI_API_KEY=${{ secrets.SPRING_AI_OPENAI_API_KEY }}" >> .env
           echo "JWT_KEY=${{ secrets.JWT_KEY }}" >> .env
+          echo "JWT_ACCESS_TOKEN_EXPIRATION=${{ secrets.JWT_ACCESS_TOKEN_EXPIRATION }}" >> .env
+          echo "JWT_REFRESH_TOKEN_EXPIRATION=${{ secrets.JWT_REFRESH_TOKEN_EXPIRATION }}" >> .env
           echo "SERVER_BASE_URL=${{ secrets.SERVER_BASE_URL }}" >> .env
           echo "SCRAPER_API_TOKEN=${{ secrets.SCRAPER_API_TOKEN }}" >> .env
           echo "SCRAPER_BASE_URL=${{ secrets.SCRAPER_BASE_URL }}" >> .env

--- a/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
@@ -1,7 +1,5 @@
 package com.adit.backend.domain.auth.controller;
 
-import java.io.IOException;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,12 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.adit.backend.domain.auth.dto.request.KakaoRequest;
 import com.adit.backend.domain.auth.dto.response.KakaoResponse;
 import com.adit.backend.domain.auth.service.command.AuthCommandService;
-import com.adit.backend.domain.user.dto.response.UserResponse;
 import com.adit.backend.global.common.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
@@ -32,23 +28,12 @@ public class AuthController {
 	public static final String ACCESS_TOKEN_HEADER = "Authorization";
 	private final AuthCommandService authCommandService;
 
-	@Operation(summary = "카카오 회원가입/로그인 요청")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "302", description = "카카오 로그인 페이지로 Redirect"),
-	})
-	@GetMapping("/kakao")
-	public void kakaoLogin(HttpServletResponse response) throws IOException {
-		String kakaoAuthUrl = authCommandService.createKakaoAuthorizationUrl();
-		response.sendRedirect(kakaoAuthUrl);
-	}
-
 	@Operation(summary = "카카오 회원가입/로그인 결과", description = "request는 https로 요청되기 때문에 때문에 로컬환경, SSL 인증 전 CORS 오류 존재, 직접 링크를 작성하여 접속")
 	@Parameter(name = "code", description = "카카오 인가 코드", required = true)
-	@GetMapping("/join")
-	public ResponseEntity<ApiResponse<UserResponse.InfoDto>> joinAuth(KakaoRequest.AuthDto request,
-		HttpServletResponse response) {
+	@GetMapping("/success")
+	public ResponseEntity<ApiResponse<KakaoRequest.AuthDto>> joinAuth(KakaoRequest.AuthDto request, HttpServletResponse response) {
 		return ResponseEntity.ok(
-			ApiResponse.success(authCommandService.joinAuth(request.code(), response)));
+			ApiResponse.success(request));
 	}
 
 	@Operation(summary = "카카오 토큰 재발급")

--- a/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
@@ -1,20 +1,18 @@
 package com.adit.backend.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.adit.backend.domain.auth.dto.request.KakaoRequest;
-import com.adit.backend.domain.auth.dto.response.KakaoResponse;
+import com.adit.backend.domain.auth.dto.response.ReissueResponse;
 import com.adit.backend.domain.auth.service.command.AuthCommandService;
 import com.adit.backend.global.common.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -23,23 +21,33 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthController {
-	public static final String ACCESS_TOKEN_HEADER = "Authorization";
-	private final AuthCommandService authCommandService;
 
-	@Operation(summary = "카카오 회원가입/로그인 결과", description = "request는 https로 요청되기 때문에 때문에 로컬환경, SSL 인증 전 CORS 오류 존재, 직접 링크를 작성하여 접속")
+	private final AuthCommandService authCommandService;
+/*
+
+	@Operation(summary = "카카오 회원가입 응답", description = "")
 	@Parameter(name = "code", description = "카카오 인가 코드", required = true)
-	@GetMapping("/success")
-	public ResponseEntity<ApiResponse<KakaoRequest.AuthDto>> joinAuth(KakaoRequest.AuthDto request, HttpServletResponse response) {
-		return ResponseEntity.ok(
-			ApiResponse.success(request));
+	@GetMapping("/join")
+	public ResponseEntity<String> joinAuth(KakaoRequest.AuthDto request,
+		HttpServletResponse response) {
+		return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다.");
+	}
+*/
+
+	@Operation(summary = "사용자 토큰 재발급", description = "사용자의 JWT 토큰을 재 발급합니다.")
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiResponse<ReissueResponse>> tokenReissue(
+		@CookieValue(name = "refreshToken") String refreshToken, @AuthenticationPrincipal UserDetails userDetails,
+		HttpServletResponse response) {
+		return ResponseEntity.ok(ApiResponse.success(authCommandService.reIssue(refreshToken, response)));
 	}
 
-	@Operation(summary = "카카오 로그아웃")
-	@DeleteMapping("/logout")
-	@SecurityRequirement(name = "accessTokenAuth")
-	public ResponseEntity<ApiResponse<KakaoResponse.UserIdDto>> logout(
-		@RequestHeader(ACCESS_TOKEN_HEADER) KakaoRequest.AccessTokenDto request, HttpServletResponse response) {
-		return ResponseEntity.ok(ApiResponse.success(authCommandService.logout(request.accessToken(), response)));
+	@Operation(summary = "사용자 로그아웃", description = "사용자의 JWT 토큰을 제거하고 로그아웃합니다.")
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(@CookieValue(name = "refreshToken") String refreshToken,
+		HttpServletResponse response) {
+		authCommandService.logout(refreshToken, response);
+		return ResponseEntity.noContent().build();
 	}
 
 }

--- a/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
@@ -1,8 +1,6 @@
 package com.adit.backend.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,7 +35,7 @@ public class AuthController {
 	@Operation(summary = "사용자 토큰 재발급", description = "사용자의 JWT 토큰을 재 발급합니다.")
 	@PostMapping("/reissue")
 	public ResponseEntity<ApiResponse<ReissueResponse>> tokenReissue(
-		@CookieValue(name = "refreshToken") String refreshToken, @AuthenticationPrincipal UserDetails userDetails,
+		@CookieValue(name = "refreshToken") String refreshToken,
 		HttpServletResponse response) {
 		return ResponseEntity.ok(ApiResponse.success(authCommandService.reIssue(refreshToken, response)));
 	}

--- a/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/adit/backend/domain/auth/controller/AuthController.java
@@ -1,10 +1,8 @@
 package com.adit.backend.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,14 +32,6 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<KakaoRequest.AuthDto>> joinAuth(KakaoRequest.AuthDto request, HttpServletResponse response) {
 		return ResponseEntity.ok(
 			ApiResponse.success(request));
-	}
-
-	@Operation(summary = "카카오 토큰 재발급")
-	@PostMapping("/reissue")
-	public ResponseEntity<ApiResponse<KakaoResponse.AccessTokenDto>> reissueToken(
-		@CookieValue(name = "refreshToken") KakaoRequest.RefreshTokenDto request, HttpServletResponse response) {
-		return ResponseEntity.ok(
-			ApiResponse.success(authCommandService.reIssueKakaoToken(request.refreshToken(), response)));
 	}
 
 	@Operation(summary = "카카오 로그아웃")

--- a/src/main/java/com/adit/backend/domain/auth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/adit/backend/domain/auth/dto/OAuth2UserInfo.java
@@ -8,14 +8,12 @@ import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.enums.Role;
 import com.adit.backend.domain.user.enums.SocialType;
 import com.adit.backend.global.security.jwt.exception.AuthException;
-import com.adit.backend.global.util.KeyGenerator;
 
 import lombok.Builder;
 
 @Builder
 public record OAuth2UserInfo(
 	String name,
-	Role role,
 	String email,
 	String profile
 ) {
@@ -46,7 +44,6 @@ public record OAuth2UserInfo(
 			.email(email)
 			.nickname(DEFAULT_NICKNAME)
 			.profile(profile)
-			.socialId(KeyGenerator.generateKey())
 			.socialType(SocialType.KAKAO)
 			.role(Role.GUEST)
 			.build();

--- a/src/main/java/com/adit/backend/domain/auth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/adit/backend/domain/auth/dto/OAuth2UserInfo.java
@@ -18,8 +18,6 @@ public record OAuth2UserInfo(
 	String profile
 ) {
 
-	public static final String DEFAULT_NICKNAME = "GUEST";
-
 	public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) throws AuthException {
 		return switch (registrationId) {
 			case "kakao" -> ofKakao(attributes);
@@ -42,7 +40,7 @@ public record OAuth2UserInfo(
 		return User.builder()
 			.name(name)
 			.email(email)
-			.nickname(DEFAULT_NICKNAME)
+			.nickname(Role.GUEST.getKey())
 			.profile(profile)
 			.socialType(SocialType.KAKAO)
 			.role(Role.GUEST)

--- a/src/main/java/com/adit/backend/domain/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/com/adit/backend/domain/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,9 @@
+package com.adit.backend.domain.auth.dto.request;
+
+import groovyjarjarantlr4.v4.runtime.misc.NotNull;
+
+public record LogoutRequest(
+	@NotNull
+	String accessToken
+) {
+}

--- a/src/main/java/com/adit/backend/domain/auth/dto/response/ReissueResponse.java
+++ b/src/main/java/com/adit/backend/domain/auth/dto/response/ReissueResponse.java
@@ -1,0 +1,9 @@
+package com.adit.backend.domain.auth.dto.response;
+
+public record ReissueResponse(
+	String accessToken
+) {
+	public static ReissueResponse from(String accessToken) {
+		return new ReissueResponse(accessToken);
+	}
+}

--- a/src/main/java/com/adit/backend/domain/auth/entity/Token.java
+++ b/src/main/java/com/adit/backend/domain/auth/entity/Token.java
@@ -28,7 +28,7 @@ public class Token {
 	private Long id;
 
 	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "social_id", referencedColumnName = "social_id")
+	@JoinColumn(name = "email", referencedColumnName = "email")
 	private User user;
 
 	private String accessToken;
@@ -36,9 +36,9 @@ public class Token {
 	private LocalDateTime tokenExpiresAt;
 	private LocalDateTime refreshTokenExpiresAt;
 
-	public Token updateRefreshToken(String refreshToken) {
+	public void updateRefreshToken(String refreshToken, String refreshTokenExpiresAt) {
 		this.refreshToken = refreshToken;
-		return this;
+		this.refreshTokenExpiresAt = LocalDateTime.now().plusSeconds(Long.parseLong(refreshTokenExpiresAt));
 	}
 
 	public void updateAccessToken(String accessToken, String tokenExpiresAt) {

--- a/src/main/java/com/adit/backend/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/adit/backend/domain/auth/repository/TokenRepository.java
@@ -13,8 +13,8 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
 
 	Optional<Token> findTokenByRefreshToken(String refreshToken);
 
-	@Query("SELECT t FROM Token t JOIN FETCH t.user WHERE t.user.socialId = :socialId")
-	Optional<Token> findByUserWithFetch(String socialId);
+	@Query("SELECT t FROM Token t JOIN FETCH t.user u WHERE u.email = :email")
+	Optional<Token> findByUserWithFetch(@Param("email") String email);
 
 	Optional<Token> findByAccessToken(String accessToken);
 

--- a/src/main/java/com/adit/backend/domain/auth/service/command/AuthCommandService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/command/AuthCommandService.java
@@ -1,36 +1,19 @@
 package com.adit.backend.domain.auth.service.command;
 
 import static com.adit.backend.global.error.GlobalErrorCode.*;
-import static org.springframework.http.MediaType.*;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
-import com.adit.backend.domain.auth.dto.response.KakaoResponse;
+import com.adit.backend.domain.auth.dto.response.ReissueResponse;
 import com.adit.backend.domain.auth.entity.Token;
-import com.adit.backend.domain.auth.service.query.TokenQueryService;
-import com.adit.backend.domain.user.converter.UserConverter;
-import com.adit.backend.domain.user.dto.response.UserResponse;
-import com.adit.backend.domain.user.entity.User;
-import com.adit.backend.domain.user.service.command.UserCommandService;
-import com.adit.backend.domain.user.service.query.UserQueryService;
-import com.adit.backend.global.error.exception.TokenException;
 import com.adit.backend.global.security.jwt.exception.AuthException;
+import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -42,88 +25,41 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthCommandService {
-	public static final String ACCESS_TOKEN_HEADER = "Authorization";
-	public static final String AUTH_CODE_GRANT = "authorization_code";
-	public static final String REFRESH_TOKEN_GRANT = "refresh_token";
-	public static final String RESPONSE_TYPE = "code";
-
-	private final RestTemplate restTemplate;
 	private final TokenCommandService tokenCommandService;
-	private final TokenQueryService tokenQueryService;
-	private final UserQueryService userQueryService;
-	private final UserCommandService userCommandService;
-
-	@Value("${spring.security.oauth2.client.registration.kakao.client-id}")
-	private String clientId;
-
-	@Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
-	private String clientSecret;
-
-	@Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
-	private String redirectUri;
-
-	@Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
-	private String authorizationUri;
-
-	@Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
-	private String tokenUri;
-
-	@Value("${kakao.logout-url}")
-	private String logoutUrl;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	@Value("${token.refresh.expiration}")
-	private int refreshTokenExpiresIn;
+	private String refreshTokenExpiresAt;
 
-	public String createKakaoAuthorizationUrl() {
-		return UriComponentsBuilder
-			.fromUriString(authorizationUri)
-			.queryParam("client_id", clientId)
-			.queryParam("redirect_uri", redirectUri)
-			.queryParam("response_type", RESPONSE_TYPE)
-			.build()
-			.toUriString();
+	@Value("${token.refresh.cookie.name}")
+	private String refreshTokenCookieName;
+
+	public ReissueResponse reIssue(String refreshToken, HttpServletResponse response) {
+		Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+		Token token = tokenCommandService.validateRefreshToken(refreshToken);
+		log.info("[브라우저에서 들어온 쿠키] == [DB에 저장된 토큰], {}", refreshToken.equals(token.getRefreshToken()));
+		if (!refreshToken.equals(token.getRefreshToken())) {
+			log.warn("[쿠키로 들어온 토큰과 DB의 토큰이 일치하지 않음.]");
+			throw new AuthException(TOKEN_NOT_FOUND);
+		}
+		jwtTokenProvider.checkRefreshTokenAndReIssueAccessToken(authentication, refreshToken);
+		addRefreshTokenToCookie(null, response);
+		return ReissueResponse.from(token.getAccessToken());
 	}
 
-	private static HttpHeaders createHeaders() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(APPLICATION_FORM_URLENCODED);
-		headers.setAccept(Collections.singletonList(APPLICATION_JSON));
-		return headers;
-	}
-
-	public UserResponse.InfoDto joinAuth(String code, HttpServletResponse response) {
-		KakaoResponse.TokenInfoDto tokenInfoDto = executeKakaoLoginRequest(code).getBody();
-		tokenCommandService.saveOrUpdateToken(tokenInfoDto);
-		response.setHeader(ACCESS_TOKEN_HEADER, tokenInfoDto.accessToken());
-		addRefreshTokenToCookie(tokenInfoDto.refreshToken(), response);
-		return login(tokenInfoDto.accessToken());
-	}
-
-	public KakaoResponse.AccessTokenDto reIssueKakaoToken(String refreshToken, HttpServletResponse response) {
-		KakaoResponse.AccessTokenDto accessTokenDto = executeReissueTokenRequest(refreshToken).getBody();
-		tokenCommandService.updateTokenEntity(accessTokenDto, refreshToken);
-		addRefreshTokenToCookie(refreshToken, response);
-		return accessTokenDto;
-	}
-
-	public KakaoResponse.UserIdDto logout(String accessToken, HttpServletResponse response) {
-		return executeKakaoLogoutRequest(accessToken.replace("Bearer ", ""), response);
-	}
-
-	private UserResponse.InfoDto login(String accessToken) {
-		OAuth2UserInfo oAuth2UserInfo = tokenQueryService.extractAccessToken(accessToken);
-		User user = userQueryService.findUserByOAuthInfo(oAuth2UserInfo);
-		Token token = tokenQueryService.findTokenByAccessToken(accessToken);
-		userCommandService.saveUserWithToken(user, token);
-		log.info("[로그인 성공] Email : {}", user.getEmail());
-		return UserConverter.InfoDto(user);
+	@Transactional
+	public void logout(String refreshToken, HttpServletResponse response) {
+		Token existToken = tokenCommandService.validateRefreshToken(refreshToken);
+		tokenCommandService.deleteToken(existToken);
+		addRefreshTokenToCookie(null, response);
+		log.info("[로그아웃 진행 완료]");
 	}
 
 	private void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
-		Cookie cookie = new Cookie(REFRESH_TOKEN_GRANT, refreshToken);
+		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
 		cookie.setPath("/");
 		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-		ZonedDateTime expirationTime = seoulTime.plusSeconds(refreshTokenExpiresIn);
+		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
 		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
 		cookie.setSecure(true);
 		cookie.setHttpOnly(true);
@@ -131,70 +67,5 @@ public class AuthCommandService {
 		log.info("[쿠키 생성 완료] Cookie: {}", cookie.getValue());
 	}
 
-	private KakaoResponse.UserIdDto executeKakaoLogoutRequest(String accessToken, HttpServletResponse response) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.setBearerAuth(accessToken);
-		try {
-			KakaoResponse.UserIdDto userIdDto = restTemplate.exchange(
-				logoutUrl,
-				HttpMethod.POST,
-				new HttpEntity<>(headers),
-				KakaoResponse.UserIdDto.class
-			).getBody();
-			deleteRefreshTokenToCookie(accessToken, response);
-			log.info("[로그아웃 성공] : {}", accessToken);
-			return userIdDto;
-		} catch (Exception e) {
-			log.error("로그아웃 실패: {}", e.getMessage());
-			throw new TokenException(LOGOUT_FAILED);
-		}
-	}
-
-	private void deleteRefreshTokenToCookie(String accessToken, HttpServletResponse response) {
-		Cookie deleteCookie = new Cookie(REFRESH_TOKEN_GRANT, null);
-		deleteCookie.setMaxAge(0);
-		deleteCookie.setPath("/");
-		deleteCookie.setSecure(true);
-		deleteCookie.setHttpOnly(true);
-		response.addCookie(deleteCookie);
-		tokenCommandService.deleteToken(accessToken);
-		log.info("[쿠키 생성 완료] deleteCookie: {}", deleteCookie.getValue());
-	}
-
-	private ResponseEntity<KakaoResponse.TokenInfoDto> executeKakaoLoginRequest(String code) {
-		HttpHeaders headers = createHeaders();
-		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-		params.add("grant_type", AUTH_CODE_GRANT);
-		params.add("client_id", clientId);
-		params.add("client_secret", clientSecret);
-		params.add("redirect_uri", redirectUri);
-		params.add("code", code);
-		return request(tokenUri, new HttpEntity<>(params, headers), KakaoResponse.TokenInfoDto.class);
-	}
-
-	private ResponseEntity<KakaoResponse.AccessTokenDto> executeReissueTokenRequest(String refreshToken) {
-		HttpHeaders headers = createHeaders();
-		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-		params.add("grant_type", REFRESH_TOKEN_GRANT);
-		params.add("client_id", clientId);
-		params.add("client_secret", clientSecret);
-		params.add("refresh_token", refreshToken);
-		return request(tokenUri, new HttpEntity<>(params, headers), KakaoResponse.AccessTokenDto.class);
-	}
-
-	private <T> ResponseEntity<T> request(String url, HttpEntity<?> entity, Class<T> responseType) {
-		try {
-			return restTemplate.postForEntity(url, entity, responseType);
-		} catch (HttpClientErrorException e) {
-			log.error("Kakao API client error: {}", e.getStatusCode());
-			throw new AuthException(INVALID_TOKEN);
-		} catch (HttpServerErrorException e) {
-			log.error("Kakao API server error: {}", e.getStatusCode());
-			throw new AuthException(KAKAO_SERVER_ERROR);
-		} catch (Exception e) {
-			log.error("Kakao API request failed: {}", e.getMessage());
-			throw new AuthException(API_REQUEST_FAILED);
-		}
-	}
 }
 

--- a/src/main/java/com/adit/backend/domain/auth/service/command/AuthCommandService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/command/AuthCommandService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.adit.backend.domain.auth.dto.response.ReissueResponse;
 import com.adit.backend.domain.auth.entity.Token;
+import com.adit.backend.domain.auth.service.query.TokenQueryService;
 import com.adit.backend.global.security.jwt.exception.AuthException;
 import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthCommandService {
+	private final TokenQueryService tokenQueryService;
 	private final TokenCommandService tokenCommandService;
 	private final JwtTokenProvider jwtTokenProvider;
 
@@ -36,7 +38,7 @@ public class AuthCommandService {
 
 	public ReissueResponse reIssue(String refreshToken, HttpServletResponse response) {
 		Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
-		Token token = tokenCommandService.validateRefreshToken(refreshToken);
+		Token token = tokenQueryService.validateRefreshToken(refreshToken);
 		log.info("[브라우저에서 들어온 쿠키] == [DB에 저장된 토큰], {}", refreshToken.equals(token.getRefreshToken()));
 		if (!refreshToken.equals(token.getRefreshToken())) {
 			log.warn("[쿠키로 들어온 토큰과 DB의 토큰이 일치하지 않음.]");
@@ -49,7 +51,7 @@ public class AuthCommandService {
 
 	@Transactional
 	public void logout(String refreshToken, HttpServletResponse response) {
-		Token existToken = tokenCommandService.validateRefreshToken(refreshToken);
+		Token existToken = tokenQueryService.validateRefreshToken(refreshToken);
 		tokenCommandService.deleteToken(existToken);
 		addRefreshTokenToCookie(null, response);
 		log.info("[로그아웃 진행 완료]");

--- a/src/main/java/com/adit/backend/domain/auth/service/command/TokenCommandService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/command/TokenCommandService.java
@@ -22,22 +22,9 @@ public class TokenCommandService {
 
 	private final TokenRepository tokenRepository;
 
-	public Token saveOrUpdateToken(KakaoResponse.TokenInfoDto response) {
-		Token token = validateAccessToken(response);
-		log.info("[토큰 저장 완료] accessToken : {} , refreshToken : {}", token.getAccessToken(), token.getRefreshToken());
-		return tokenRepository.save(token);
-	}
-
-	public Token updateTokenEntity(KakaoResponse.AccessTokenDto response, String refreshToken) {
-		Token token = validateRefreshToken(refreshToken);
-		token.updateAccessToken(response.accessToken(), response.expiresIn());
-		log.info("[토큰 갱신 완료] accessToken : {} , refreshToken : {}", token.getAccessToken(), token.getRefreshToken());
-		return tokenRepository.save(token);
-	}
-
-	public void deleteToken(String accessToken) {
-		tokenRepository.deleteByAccessToken(accessToken);
-		log.info("[토큰 삭제 완료] accessToken : {}", accessToken);
+	public void deleteToken(Token token) {
+		tokenRepository.delete(token);
+		log.info("[토큰 삭제 완료] accessToken : {}", token.getUser().getEmail());
 		tokenRepository.flush();
 	}
 
@@ -46,7 +33,7 @@ public class TokenCommandService {
 			.orElseGet(response::toEntity);
 	}
 
-	private Token validateRefreshToken(String refreshToken) {
+	public Token validateRefreshToken(String refreshToken) {
 		return tokenRepository.findTokenByRefreshToken(refreshToken)
 			.orElseThrow(() -> new TokenException(TOKEN_NOT_FOUND));
 	}

--- a/src/main/java/com/adit/backend/domain/auth/service/command/TokenCommandService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/command/TokenCommandService.java
@@ -1,14 +1,10 @@
 package com.adit.backend.domain.auth.service.command;
 
-import static com.adit.backend.global.error.GlobalErrorCode.*;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.adit.backend.domain.auth.dto.response.KakaoResponse;
 import com.adit.backend.domain.auth.entity.Token;
 import com.adit.backend.domain.auth.repository.TokenRepository;
-import com.adit.backend.global.error.exception.TokenException;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -25,16 +21,5 @@ public class TokenCommandService {
 	public void deleteToken(Token token) {
 		tokenRepository.delete(token);
 		log.info("[토큰 삭제 완료] accessToken : {}", token.getUser().getEmail());
-		tokenRepository.flush();
-	}
-
-	private Token validateAccessToken(KakaoResponse.TokenInfoDto response) {
-		return tokenRepository.findByAccessToken(response.accessToken())
-			.orElseGet(response::toEntity);
-	}
-
-	public Token validateRefreshToken(String refreshToken) {
-		return tokenRepository.findTokenByRefreshToken(refreshToken)
-			.orElseThrow(() -> new TokenException(TOKEN_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/adit/backend/domain/auth/service/query/TokenQueryService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/query/TokenQueryService.java
@@ -2,55 +2,30 @@ package com.adit.backend.domain.auth.service.query;
 
 import static com.adit.backend.global.error.GlobalErrorCode.*;
 
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
+import com.adit.backend.domain.auth.dto.response.KakaoResponse;
 import com.adit.backend.domain.auth.entity.Token;
 import com.adit.backend.domain.auth.repository.TokenRepository;
 import com.adit.backend.global.error.exception.TokenException;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenQueryService {
-
-	private final static String KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
-	private final RestTemplate restTemplate;
 	private final TokenRepository tokenRepository;
 
-	private ResponseEntity<JsonNode> callKakaoApi(String accessToken) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.setBearerAuth(accessToken);
-		HttpEntity<Void> request = new HttpEntity<>(headers);
-		return restTemplate.exchange(KAKAO_USER_INFO_URI, HttpMethod.GET, request, JsonNode.class);
+	private Token validateAccessToken(KakaoResponse.TokenInfoDto response) {
+		return tokenRepository.findByAccessToken(response.accessToken())
+			.orElseGet(response::toEntity);
 	}
 
-	public OAuth2UserInfo extractAccessToken(String accessToken) {
-		ResponseEntity<JsonNode> response = callKakaoApi(accessToken);
-		JsonNode userInfo = response.getBody();
-		String name = userInfo.path("kakao_account").path("profile").path("nickname").asText();
-		String email = userInfo.path("kakao_account").path("email").asText();
-		String profileImageUrl = userInfo.path("kakao_account").path("profile").path("thumbnail_image_url").asText();
-
-		return OAuth2UserInfo.builder()
-			.name(name)
-			.email(email)
-			.profile(profileImageUrl)
-			.build();
-	}
-
-	public Token findTokenByAccessToken(String accessToken) {
-		return tokenRepository.findByAccessToken(accessToken)
+	public Token validateRefreshToken(String refreshToken) {
+		return tokenRepository.findTokenByRefreshToken(refreshToken)
 			.orElseThrow(() -> new TokenException(TOKEN_NOT_FOUND));
 	}
 

--- a/src/main/java/com/adit/backend/domain/auth/service/query/TokenQueryService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/query/TokenQueryService.java
@@ -13,7 +13,6 @@ import org.springframework.web.client.RestTemplate;
 import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
 import com.adit.backend.domain.auth.entity.Token;
 import com.adit.backend.domain.auth.repository.TokenRepository;
-import com.adit.backend.domain.user.enums.Role;
 import com.adit.backend.global.error.exception.TokenException;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -45,7 +44,6 @@ public class TokenQueryService {
 
 		return OAuth2UserInfo.builder()
 			.name(name)
-			.role(Role.GUEST)
 			.email(email)
 			.profile(profileImageUrl)
 			.build();

--- a/src/main/java/com/adit/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/adit/backend/domain/user/converter/UserConverter.java
@@ -9,7 +9,6 @@ public class UserConverter {
 			.email(user.getEmail())
 			.name(user.getName())
 			.nickname(user.getNickname())
-			.socialId(user.getSocialId())
 			.role(user.getRole())
 			.build();
 	}

--- a/src/main/java/com/adit/backend/domain/user/entity/User.java
+++ b/src/main/java/com/adit/backend/domain/user/entity/User.java
@@ -56,7 +56,7 @@ public class User extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	private Role role;
 
-	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToOne(mappedBy = "user", orphanRemoval = true)
 	private Token token;
 
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/adit/backend/domain/user/entity/User.java
+++ b/src/main/java/com/adit/backend/domain/user/entity/User.java
@@ -39,7 +39,7 @@ public class User extends BaseEntity {
 	@Column(nullable = false, length = 10)
 	private String name;
 
-	@Column(nullable = false, length = 20, unique = true)
+	@Column(nullable = false, unique = true)
 	private String email;
 
 	@Column(nullable = false, length = 50)
@@ -47,9 +47,6 @@ public class User extends BaseEntity {
 
 	@Column(nullable = false)
 	private String profile;
-
-	@Column(name = "social_id", nullable = false, unique = true)
-	private String socialId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -75,13 +72,11 @@ public class User extends BaseEntity {
 	private List<Friendship> receivedFriendRequests = new ArrayList<>();
 
 	@Builder
-	public User(String name, String email, String nickname, String profile, String socialId, SocialType socialType,
-		Role role) {
+	public User(String name, String email, String nickname, String profile, SocialType socialType, Role role) {
 		this.name = name;
 		this.email = email;
 		this.nickname = nickname;
 		this.profile = profile;
-		this.socialId = socialId;
 		this.socialType = socialType;
 		this.role = role;
 	}

--- a/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetails.java
+++ b/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetails.java
@@ -39,7 +39,7 @@ public record PrincipalDetails(
 
 	@Override
 	public String getUsername() {
-		return user.getSocialId();
+		return user.getEmail();
 	}
 
 	@Override

--- a/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetailsService.java
@@ -25,8 +25,8 @@ public class PrincipalDetailsService implements UserDetailsService {
 	private final UserRepository userRepository;
 
 	@Override
-	public PrincipalDetails loadUserByUsername(String socialId) throws UsernameNotFoundException {
-		User user = userRepository.findBySocialId(socialId)
+	public PrincipalDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		User user = userRepository.findByEmail(email)
 			.orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
 		return new PrincipalDetails(
@@ -44,8 +44,8 @@ public class PrincipalDetailsService implements UserDetailsService {
 		);
 	}
 
-	public User getUser(String socialId) {
-		return userRepository.findBySocialId(socialId)
+	public User getUser(String email) {
+		return userRepository.findByEmail(email)
 			.orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetailsService.java
@@ -1,7 +1,5 @@
 package com.adit.backend.domain.user.principal;
 
-import static com.adit.backend.global.error.GlobalErrorCode.*;
-
 import java.util.Collections;
 import java.util.Map;
 
@@ -11,8 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.adit.backend.domain.user.entity.User;
-import com.adit.backend.domain.user.repository.UserRepository;
-import com.adit.backend.global.error.exception.BusinessException;
+import com.adit.backend.domain.user.service.query.UserQueryService;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -22,18 +19,12 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class PrincipalDetailsService implements UserDetailsService {
 
-	private final UserRepository userRepository;
+	private final UserQueryService userQueryService;
 
 	@Override
 	public PrincipalDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-		User user = userRepository.findByEmail(email)
-			.orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
-
-		return new PrincipalDetails(
-			user,
-			Collections.emptyMap(),
-			"id"
-		);
+		User user = userQueryService.findUserByEmail(email);
+		return createPrincipalDetails(user, Collections.emptyMap(), "id");
 	}
 
 	public PrincipalDetails createPrincipalDetails(User user, Map<String, Object> attributes, String attributeKey) {
@@ -44,8 +35,4 @@ public class PrincipalDetailsService implements UserDetailsService {
 		);
 	}
 
-	public User getUser(String email) {
-		return userRepository.findByEmail(email)
-			.orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
-	}
 }

--- a/src/main/java/com/adit/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/adit/backend/domain/user/repository/UserRepository.java
@@ -1,11 +1,9 @@
 package com.adit.backend.domain.user.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.adit.backend.domain.user.entity.User;
@@ -13,8 +11,6 @@ import com.adit.backend.domain.user.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
-
-	Optional<User> findBySocialId(String socialId);
 
 	boolean existsByNickname(String nickname);
 

--- a/src/main/java/com/adit/backend/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/adit/backend/domain/user/service/query/UserQueryService.java
@@ -9,6 +9,7 @@ import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.exception.UserException;
 import com.adit.backend.domain.user.repository.UserRepository;
+import com.adit.backend.global.error.exception.BusinessException;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,11 @@ public class UserQueryService {
 
 	private final UserRepository userRepository;
 	public static final String DEFAULT_NICKNAME = "GUEST";
+
+	public User findUserByEmail(String email) {
+		return userRepository.findByEmail(email)
+			.orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+	}
 
 	public User findUserByAccessToken(String accessToken) {
 		return userRepository.findUserByToken_AccessToken(accessToken)

--- a/src/main/java/com/adit/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/adit/backend/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class SecurityConfig {
 
-	public static final String[] WHITE_LIST = {
+	private static final String[] WHITE_LIST = {
 		"/",
 		"/login/**",
 		"/api/ai/**",

--- a/src/main/java/com/adit/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/adit/backend/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.CorsFilter;
 
 import com.adit.backend.global.security.jwt.filter.JwtAuthenticationFilter;
@@ -33,6 +34,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class SecurityConfig {
 
+	public static final String[] WHITE_LIST = {
+		"/",
+		"/login/**",
+		"/api/ai/**",
+		"/api/user/**",
+		"/api/auth/**",
+		"/swagger-ui/**",
+		"/swagger-ui.html",
+		"/v3/api-docs/**",
+		"/swagger-resources/**",
+		"/webjars/**",
+		"/api/scraper/**",
+		"/oauth2/**"
+	};
 	private final CorsFilter corsFilter;
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
@@ -61,21 +76,10 @@ public class SecurityConfig {
 			.sessionManagement(session ->
 				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.addFilter(corsFilter)
+
 			.authorizeHttpRequests(request -> request
-				.requestMatchers(
-					"/",
-					"/login/**",
-					"/api/ai/**",
-					"/api/user/**",
-					"/api/auth/**",
-					"/swagger-ui/**",
-					"/swagger-ui.html",
-					"/v3/api-docs/**",
-					"/swagger-resources/**",
-					"/webjars/**",
-					"/api/scraper/**",
-					"/oauth2/**"  // OAuth2 엔드포인트 추가
-				).permitAll()
+				.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+				.requestMatchers(WHITE_LIST).permitAll()
 				.anyRequest().authenticated()
 			)
 			// OAuth2 로그인 설정 추가

--- a/src/main/java/com/adit/backend/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/adit/backend/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -48,7 +48,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				setAuthentication(accessToken);
 				return;
 			}
-
 			if (refreshToken != null && tokenProvider.isRefreshTokenValid(refreshToken)) {
 				reissueAccessToken(refreshToken);
 			}

--- a/src/main/java/com/adit/backend/global/security/jwt/util/JwtTokenProvider.java
+++ b/src/main/java/com/adit/backend/global/security/jwt/util/JwtTokenProvider.java
@@ -23,7 +23,6 @@ import org.springframework.util.StringUtils;
 
 import com.adit.backend.domain.auth.repository.TokenRepository;
 import com.adit.backend.domain.auth.service.query.TokenQueryService;
-import com.adit.backend.domain.user.principal.PrincipalDetails;
 import com.adit.backend.global.error.exception.TokenException;
 import com.adit.backend.global.security.jwt.service.JwtTokenService;
 
@@ -99,8 +98,10 @@ public class JwtTokenProvider {
 			.map(GrantedAuthority::getAuthority)
 			.collect(Collectors.joining());
 
+		String subject = authentication.getName();
+
 		return Jwts.builder()
-			.subject(((PrincipalDetails)authentication.getPrincipal()).getUser().getEmail()) // email을 subject로 사용
+			.subject(subject)
 			.claim(KEY_ROLE, authorities)
 			.issuedAt(now)
 			.expiration(expiredDate)

--- a/src/main/java/com/adit/backend/global/security/jwt/util/JwtTokenProvider.java
+++ b/src/main/java/com/adit/backend/global/security/jwt/util/JwtTokenProvider.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import com.adit.backend.domain.auth.repository.TokenRepository;
 import com.adit.backend.domain.auth.service.query.TokenQueryService;
 import com.adit.backend.domain.user.principal.PrincipalDetails;
 import com.adit.backend.global.error.exception.TokenException;
@@ -49,6 +50,7 @@ public class JwtTokenProvider {
 
 	private static SecretKey secretKey;
 	private final JwtTokenService jwtTokenService;
+	private final TokenRepository tokenRepository;
 	@Value("${token.key}")
 	private String key;
 	@Value("${token.access.expiration}")

--- a/src/main/java/com/adit/backend/global/security/jwt/util/JwtTokenProvider.java
+++ b/src/main/java/com/adit/backend/global/security/jwt/util/JwtTokenProvider.java
@@ -2,6 +2,8 @@ package com.adit.backend.global.security.jwt.util;
 
 import static com.adit.backend.global.error.GlobalErrorCode.*;
 
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -16,9 +18,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import com.adit.backend.domain.auth.entity.Token;
+import com.adit.backend.domain.auth.service.query.TokenQueryService;
+import com.adit.backend.domain.user.principal.PrincipalDetails;
 import com.adit.backend.global.error.exception.TokenException;
 import com.adit.backend.global.security.jwt.service.JwtTokenService;
 
@@ -30,41 +34,34 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class JwtTokenProvider {
-	@Value("${jwt.key}")
-	private String key;
+	private final TokenQueryService tokenService;
 
 	private static final String BEARER = "Bearer ";
 	private static final String KEY_ROLE = "role";
 
 	private static SecretKey secretKey;
 	private final JwtTokenService jwtTokenService;
-
-	@Value("${jwt.access.expiration}")
-	private Long accessTokenExpirationPeriod;
-
-	@Value("${jwt.refresh.expiration}")
-	private Long refreshTokenExpirationPeriod;
-
-	@Value("${jwt.access.header}")
-	private String accessHeader;
-
-	@Value("${jwt.refresh.header}")
-	private String refreshHeader;
-
-	@PostConstruct
-	private void setSecretKey() {
-		secretKey = Keys.hmacShaKeyFor(key.getBytes());
-	}
+	@Value("${token.key}")
+	private String key;
+	@Value("${token.access.expiration}")
+	private Long accessTokenExpirationAt;
+	@Value("${token.refresh.expiration}")
+	private Long refreshTokenExpirationAt;
+	@Value("${token.access.header}")
+	private String accessTokenHeader;
+	@Value("${token.refresh.cookie.name}")
+	private String refreshCookieName;
 
 	private static Claims parseClaims(String token) {
+		log.info("token:, {}", token);
 		if (!StringUtils.hasText(token)) {
 			throw new TokenException(INVALID_TOKEN);
 		}
@@ -79,6 +76,19 @@ public class JwtTokenProvider {
 		}
 	}
 
+	@PostConstruct
+	private void setSecretKey() {
+		byte[] keyBytes = Base64.getDecoder().decode(key);
+		secretKey = Keys.hmacShaKeyFor(keyBytes);
+		validateKeyStrength(keyBytes);
+	}
+
+	private void validateKeyStrength(byte[] keyBytes) {
+		if (keyBytes.length < 32) { // 256 bits
+			throw new IllegalArgumentException("Secret key must be at least 256 bits long");
+		}
+	}
+
 	private String generateToken(Authentication authentication, long expireTime) {
 		Date now = new Date();
 		Date expiredDate = new Date(now.getTime() + expireTime);
@@ -88,40 +98,32 @@ public class JwtTokenProvider {
 			.collect(Collectors.joining());
 
 		return Jwts.builder()
-			.subject(authentication.getName())
+			.subject(((PrincipalDetails)authentication.getPrincipal()).getUser().getEmail()) // email을 subject로 사용
 			.claim(KEY_ROLE, authorities)
 			.issuedAt(now)
 			.expiration(expiredDate)
-			.signWith(secretKey, Jwts.SIG.HS512)
+			.signWith(secretKey, Jwts.SIG.HS256)
 			.compact();
 	}
 
 	public String generateAccessToken(Authentication authentication) {
-		return generateToken(authentication, accessTokenExpirationPeriod);
+		return generateToken(authentication, accessTokenExpirationAt);
 	}
 
-	// 1. refresh token 발급
 	public String generateRefreshToken(Authentication authentication) {
-		return generateToken(authentication, refreshTokenExpirationPeriod);
+		return generateToken(authentication, refreshTokenExpirationAt);
 	}
 
 	public String checkRefreshTokenAndReIssueAccessToken(Authentication authentication, String refreshToken) {
-		Token token = jwtTokenService.findByAccessTokenOrThrow(refreshToken);
-		if (isRefreshTokenValid(refreshToken)) {
-			String reIssuedRefreshToken = reissueRefreshToken(authentication, token);
-			String reIssueAccessToken = generateAccessToken(getAuthentication(reIssuedRefreshToken));
-			jwtTokenService.updateAccessToken(reIssueAccessToken, token);
-			return reIssueAccessToken;
-		} else {
-			throw new TokenException(REFRESH_TOKEN_EXPIRED);
-		}
-
-	}
-
-	public String reissueRefreshToken(Authentication authentication, Token token) {
-		String reIssuedRefreshToken = generateRefreshToken(authentication);
-		jwtTokenService.updateRefreshToken(reIssuedRefreshToken, token);
-		return reIssuedRefreshToken;
+		return jwtTokenService.findByAccessTokenOrThrow(refreshToken)
+			.filter(token -> isRefreshTokenValid(refreshToken))
+			.map(token -> {
+				String newRefreshToken = generateRefreshToken(authentication);
+				String newAccessToken = generateAccessToken(authentication);
+				jwtTokenService.updateTokens(newAccessToken, newRefreshToken, token);
+				return newAccessToken;
+			})
+			.orElseThrow(() -> new TokenException(REFRESH_TOKEN_EXPIRED));
 	}
 
 	public boolean isRefreshTokenValid(String refreshToken) {
@@ -142,38 +144,28 @@ public class JwtTokenProvider {
 				throw new TokenException(TOKEN_NOT_FOUND);
 			}
 			Claims claims = parseClaims(accessToken);
-			if (claims.getExpiration().before(new Date())) {
-				throw new TokenException(ACCESS_TOKEN_EXPIRED);
-			}
-			return true;
+			return !claims.getExpiration().before(new Date());
 		} catch (SecurityException | MalformedJwtException e) {
 			throw new TokenException(INVALID_JWT_SIGNATURE);
 		} catch (ExpiredJwtException e) {
 			throw new TokenException(ACCESS_TOKEN_EXPIRED);
 		} catch (UnsupportedJwtException e) {
 			throw new TokenException(TOKEN_UNSURPPORTED);
-		} catch (IllegalArgumentException e) {
-			throw new TokenException(INVALID_TOKEN);
 		}
 	}
 
 	public Optional<String> extractAccessToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(accessHeader))
+		return Optional.ofNullable(request.getHeader(accessTokenHeader))
 			.filter(refreshToken -> refreshToken.startsWith(BEARER))
 			.map(refreshToken -> refreshToken.replace(BEARER, ""));
 	}
 
 	public Optional<String> extractRefreshToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(refreshHeader))
-			.filter(refreshToken -> refreshToken.startsWith(BEARER))
-			.map(refreshToken -> refreshToken.replace(BEARER, ""));
-	}
-
-	public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
-		response.setStatus(HttpServletResponse.SC_OK);
-		response.setHeader(accessHeader, accessToken);
-		response.setHeader(refreshHeader, refreshToken);
-		log.info("Access Token, Refresh Token 헤더 설정 완료");
+		return Optional.ofNullable(
+			Arrays.stream(request.getCookies())
+				.filter(cookie -> cookie.getName().equals(refreshCookieName))
+				.findFirst()
+				.get().getValue());
 	}
 
 	private Authentication createAuthentication(Claims claims, String token) {
@@ -184,9 +176,12 @@ public class JwtTokenProvider {
 
 	public Authentication getAuthentication(String token) {
 		try {
-			Claims parsedClaims = parseClaims(token);
-			return createAuthentication(parsedClaims, token);
-		} catch (ExpiredJwtException e) {
+			Claims claims = parseClaims(token);
+			Authentication auth = createAuthentication(claims, token);
+			log.debug("Authentication created for user: {}", claims.getSubject());
+			return auth;
+		} catch (Exception e) {
+			log.error("Failed to create authentication from token", e);
 			throw new TokenException(ACCESS_TOKEN_EXPIRED);
 		}
 	}
@@ -194,10 +189,5 @@ public class JwtTokenProvider {
 	private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
 		return Collections.singletonList(new SimpleGrantedAuthority(
 			claims.get(KEY_ROLE).toString()));
-	}
-
-	public Optional<String> getSocialId(String token) {
-		Claims claims = parseClaims(token);
-		return Optional.ofNullable(claims.getSubject());
 	}
 }

--- a/src/main/java/com/adit/backend/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/adit/backend/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -1,19 +1,18 @@
 package com.adit.backend.global.security.oauth.handler;
 
-import static com.adit.backend.global.error.GlobalErrorCode.*;
-
-import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.stereotype.Component;
 
 import com.adit.backend.domain.user.principal.PrincipalDetails;
-import com.adit.backend.global.error.exception.BusinessException;
 import com.adit.backend.global.security.jwt.service.JwtTokenService;
 import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
@@ -21,41 +20,42 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-	private static final String REDIRECT_URI = "/api/auth/kakao";
-	@Value("${jwt.access.expiration}")
-	private Long accessTokenExpirationPeriod;
+	@Value("${token.refresh.expiration}")
+	private Long refreshTokenExpirationAt;
+
+	@Value("${token.access.header}")
+	private String accessTokenHeader;
+
+	@Value("${token.refresh.cookie.name}")
+	private String refreshTokenCookieName;
 
 	private final JwtTokenProvider tokenProvider;
 	private final JwtTokenService jwtTokenService;
 
 	@Override
-	public void onAuthenticationSuccess(HttpServletRequest request,
-		HttpServletResponse response,
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) {
-		try {
+		PrincipalDetails userDetails = getUserDetails(authentication);
+		String accessToken = tokenProvider.generateAccessToken(authentication);
+		String refreshToken = tokenProvider.generateRefreshToken(authentication);
+		jwtTokenService.saveOrUpdate(userDetails.getUsername(), refreshToken, accessToken);
 
-			PrincipalDetails userDetails = getUserDetails(authentication);
-			String accessToken = tokenProvider.generateAccessToken(authentication);
-			String refreshToken = tokenProvider.generateRefreshToken(authentication);
+		response.setHeader(accessTokenHeader, accessToken);
+		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+		cookie.setPath("/");
+		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+		ZonedDateTime expirationTime = seoulTime.plusSeconds(refreshTokenExpirationAt);
+		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		response.addCookie(cookie);
+		log.info("로그인에 성공하였습니다. email | AccessToken | RefreshToken: {} | {} | {}",
+			userDetails.getUsername(), accessToken, refreshToken);
 
-			jwtTokenService.saveOrUpdate(userDetails.getUsername(), refreshToken, accessToken);
-			tokenProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
-
-			String targetUrl = UriComponentsBuilder.fromUriString(REDIRECT_URI)
-				.queryParam("accessToken", accessToken)
-				.queryParam("refreshToken", refreshToken)
-				.build().toUriString();
-
-			log.info("로그인에 성공하였습니다. 유저 Social ID : {}", userDetails.getUsername());
-			log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
-			log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpirationPeriod);
-			response.sendRedirect(targetUrl);
-		} catch (IOException e) {
-			throw new BusinessException(IO_ERROR);
-		}
 	}
 
 	private PrincipalDetails getUserDetails(Authentication authentication) {

--- a/src/main/java/com/adit/backend/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/global/security/oauth/service/CustomOAuth2UserService.java
@@ -1,7 +1,5 @@
 package com.adit.backend.global.security.oauth.service;
 
-import java.util.Map;
-
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -13,6 +11,7 @@ import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.principal.PrincipalDetails;
 import com.adit.backend.domain.user.repository.UserRepository;
+import com.adit.backend.domain.user.service.query.UserQueryService;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -24,33 +23,34 @@ import lombok.extern.slf4j.Slf4j;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	private final UserRepository userRepository;
+	private final UserQueryService userQueryService;
 
 	@Override
 	@Transactional
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oauth2User = super.loadUser(userRequest);
+		// 예외 처리 추가
+		try {
+			return this.process(userRequest, oauth2User);
+		} catch (Exception ex) {
+			log.error("OAuth2 로그인 처리 중 에러 발생: {}", ex.getMessage());
+			throw new OAuth2AuthenticationException(ex.getMessage());
+		}
+	}
 
-		log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
-
-		// 유저 정보 가져오기
-		Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
-
-		// registrationId로 어떤 OAuth2 로그인인지 구분
+	private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User oauth2User) {
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		String userNameAttributeName = userRequest.getClientRegistration()
+			.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
 
-		String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
-			.getUserInfoEndpoint().getUserNameAttributeName();
+		OAuth2UserInfo userInfo = OAuth2UserInfo.of(registrationId, oauth2User.getAttributes());
+		User user = getOrSaveUser(userInfo);
 
-		// OAuth2UserInfo 생성
-		OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(registrationId, oAuth2UserAttributes);
-		// 유저 생성 또는 업데이트
-		User user = getOrSaveUser(oAuth2UserInfo);
-
-		return new PrincipalDetails(user, oAuth2UserAttributes, userNameAttributeName);
+		return new PrincipalDetails(user, oauth2User.getAttributes(), userNameAttributeName);
 	}
 
 	private User getOrSaveUser(OAuth2UserInfo oAuth2UserInfo) {
-		User user = userRepository.findByEmail(oAuth2UserInfo.email())
-			.orElseGet(oAuth2UserInfo::toEntity);
+		User user = userQueryService.findUserByOAuthInfo(oAuth2UserInfo);
 		user.decideSocialType();
 		return userRepository.save(user);
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,7 @@ token:
   refresh:
     expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
     cookie:
-      name: refresh
+      name: refreshToken
 
 apify:
   token: ${SCRAPER_API_TOKEN}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: ${base.url}/api/auth/join
+            redirect-uri: ${base.url}/login/oauth2/code/kakao
             client-authentication-method: client_secret_post # kakao는 인증 토큰 발급 요청 메서드가 post이다. (최근 버전에는 작성 방법이 이렇게 바뀌었다.)
             authorization-grant-type: authorization_code
             scope: # kakao 개인 정보 동의 항목 설정의 ID 값
@@ -41,7 +41,8 @@ spring:
 
 logging:
   level:
-    org.springframework.ai: DEBUG
+    org.springframework.security: DEBUG
+    org.springframework.security.oauth2: DEBUG
 
 kakao:
   logout-url: https://kapi.kakao.com/v1/user/logout
@@ -49,11 +50,12 @@ kakao:
 token:
   key: ${JWT_KEY}
   access:
-    expiration: 43200
+    expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
     header: Authorization
   refresh:
-    expiration: 5184000
-    header: Authorization-refresh
+    expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
+    cookie:
+      name: refresh
 
 apify:
   token: ${SCRAPER_API_TOKEN}


### PR DESCRIPTION
## 💡 작업 내용

- [x] JWT 토큰 자체 발급 구현
- [x] 유저 인증 시 `socialId` 대신 `email` 을 이용하도록 변경

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)
- 기존에 구현한 코드가 Kakao Rest API를 통해 소셜 로그인 진행시 발급한 Access Token을 그대로 사용하는 방식어있지만, 해당 토큰을 통해 사용자 정보를 열람할 수 있는 보안 이슈가 존재하여 기존에 구현 후 적용하지 않았던 JWT 발급 로직을 적용

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
