### PR TITLE
특정 플랫폼 이미지 추출 및 저장 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
     //S3 의존성
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 
     // .env 파일 관리
     implementation 'me.paulschwarz:spring-dotenv:3.0.0'
@@ -61,6 +62,8 @@ dependencies {
 
     // Jackson
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
+
+
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/adit/backend/domain/image/controller/ImageController.java
+++ b/src/main/java/com/adit/backend/domain/image/controller/ImageController.java
@@ -13,17 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.adit.backend.domain.image.converter.ImageConverter;
-import com.adit.backend.domain.image.dto.request.ImageRequestDto;
 import com.adit.backend.domain.image.dto.response.ImageResponseDto;
 import com.adit.backend.domain.image.entity.Image;
 import com.adit.backend.domain.image.service.command.ImageCommandService;
 import com.adit.backend.domain.image.service.query.ImageQueryService;
 import com.adit.backend.global.common.ApiResponse;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -37,13 +34,11 @@ public class ImageController {
 	private final ImageCommandService imageCommandService;
 	private final ImageConverter imageConverter;
 
-	@Hidden
 	@PostMapping
-	@Operation(summary = "이미지 업로드", description = "이미지 정보를 받아서 저장하고 저장된 이미지를 반환합니다.")
-	public ResponseEntity<ApiResponse<ImageResponseDto>> uploadImage(
-		@Valid @RequestBody ImageRequestDto requestDto) {
+	@Operation(summary = "이미지 업로드", description = "이미지 URL을 기반으로 S3에 이미지를 업로드합니다.")
+	public ResponseEntity<ApiResponse<String>> uploadImage(@RequestBody String url) {
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(ApiResponse.success(imageCommandService.uploadImage(requestDto)));
+			.body(ApiResponse.success(imageCommandService.uploadImage(url)));
 	}
 
 	@GetMapping("/{imageId}")

--- a/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
@@ -1,6 +1,6 @@
 package com.adit.backend.domain.image.service.command;
 
-import static com.adit.backend.global.error.GlobalErrorCode.*;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,7 +11,6 @@ import com.adit.backend.domain.event.entity.CommonEvent;
 import com.adit.backend.domain.event.entity.UserEvent;
 import com.adit.backend.domain.event.repository.UserEventRepository;
 import com.adit.backend.domain.image.converter.ImageConverter;
-import com.adit.backend.domain.image.dto.request.ImageRequestDto;
 import com.adit.backend.domain.image.dto.response.ImageResponseDto;
 import com.adit.backend.domain.image.entity.Image;
 import com.adit.backend.domain.image.repository.ImageRepository;
@@ -21,7 +20,6 @@ import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.UserPlace;
 import com.adit.backend.domain.place.repository.CommonPlaceRepository;
 import com.adit.backend.domain.user.entity.User;
-import com.adit.backend.global.error.exception.BusinessException;
 import com.adit.backend.infra.s3.service.AwsS3Service;
 
 import lombok.AccessLevel;
@@ -36,6 +34,7 @@ public class ImageCommandService {
 	public static final String USER_DIR_PATH = "USER/";
 	public static final String PLACE_DIR_PATH = "PLACE";
 	public static final String EVENT_DIR_PATH = "EVENT";
+	public static final String TEST_DIR_PATH = "TEST";
 	private final CommonPlaceRepository commonPlaceRepository;
 	private final ImageRepository imageRepository;
 	private final UserEventRepository userEventRepository;
@@ -43,21 +42,8 @@ public class ImageCommandService {
 	private final AwsS3Service s3Service;
 	private final ImageQueryService imageQueryService;
 
-	public ImageResponseDto uploadImage(ImageRequestDto requestDto) {
-		CommonPlace place = commonPlaceRepository.findById(requestDto.commonPlace().getId())
-			.orElseThrow(() -> new BusinessException("Place not found", NOT_FOUND_ERROR));
-
-		UserEvent userEvent =
-			requestDto.userEvent().getId() != null ? userEventRepository.findById(requestDto.userEvent().getId())
-				.orElseThrow(() -> new BusinessException("Event not found", NOT_FOUND_ERROR)) : null;
-
-		Image image = Image.builder()
-			.commonPlace(place)
-			.userEvent(userEvent)
-			.url(requestDto.url())
-			.build();
-		imageRepository.save(image);
-		return imageConverter.toResponse(image);
+	public String uploadImage(String url) {
+		return s3Service.uploadFile(List.of(url), TEST_DIR_PATH).get(0).getUrl();
 	}
 
 	public ImageResponseDto updateImage(Long imageId, MultipartFile multipartFile) {

--- a/src/main/java/com/adit/backend/global/util/ImageUtil.java
+++ b/src/main/java/com/adit/backend/global/util/ImageUtil.java
@@ -23,6 +23,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ImageUtil {
 
+	public static final String FILE_NAME_PARAM = "fname=";
+	public static final String HTTPS = "https://";
+	public static final String HTTP = "http://";
+
 	/**
 	 * 주어진 이미지 URL을 읽어 MultipartFile로 변환하여 반환한다.
 	 *
@@ -61,16 +65,6 @@ public class ImageUtil {
 		try {
 			URL url = new URL(fileUrl);
 			String query = url.getQuery();
-			if (query != null && query.contains("fname=")) {
-				for (String param : query.split("&")) {
-					if (param.startsWith("fname=")) {
-						String fnameValue = param.substring("fname=".length());
-						// 디코딩하여 원래의 URL 형태로 복원
-						String decodedFname = URLDecoder.decode(fnameValue, StandardCharsets.UTF_8);
-						return decodedFname.isEmpty() ? "unknown" : decodedFname;
-					}
-				}
-			}
 			StringBuilder fileName = new StringBuilder(new File(url.getPath()).getName());
 			if (query != null && !query.isEmpty()) {
 				for (String param : query.split("&")) {
@@ -87,8 +81,19 @@ public class ImageUtil {
 	}
 
 	private static String normalizeUrl(String imageUrl) {
-		if (!imageUrl.startsWith("http://") && !imageUrl.startsWith("https://")) {
-			return "https://" + imageUrl;
+		if (imageUrl.contains(FILE_NAME_PARAM)) {
+			String fileName = imageUrl.substring(imageUrl.indexOf(FILE_NAME_PARAM) + FILE_NAME_PARAM.length());
+			fileName = fileName.contains("&") ? fileName.substring(0, fileName.indexOf("&")) : fileName;
+			String decoded = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+			if (decoded.startsWith(HTTP) || decoded.startsWith(HTTPS)) {
+				return decoded;
+			}
+		}
+		if (imageUrl.startsWith("//")) {
+			return "https:" + imageUrl;
+		}
+		if (!imageUrl.startsWith(HTTP) && !imageUrl.startsWith(HTTPS)) {
+			return HTTPS + imageUrl;
 		}
 		return imageUrl;
 	}

--- a/src/main/java/com/adit/backend/global/util/ImageUtil.java
+++ b/src/main/java/com/adit/backend/global/util/ImageUtil.java
@@ -8,6 +8,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.apache.tomcat.util.http.fileupload.IOUtils;
@@ -30,12 +33,18 @@ public class ImageUtil {
 	// URL로부터 데이터를 읽어와서 CustomMultipartFile로 변환하여 반환
 	public static MultipartFile convertUrlToMultipartFile(String imageUrl) {
 		try {
-			URL url = new URL(imageUrl);
-			String contentType = url.openConnection().getContentType();
-			String fileName = extractFileName(imageUrl);
+			// URL에 프로토콜이 누락된 경우 "https://"를 추가함
+			String normalizedUrl = normalizeUrl(imageUrl);
+			URL url = new URL(normalizedUrl);
+			URLConnection connection = url.openConnection();
+			connection.setConnectTimeout(5000);
+			connection.setReadTimeout(5000);
+			String contentType = connection.getContentType();
 
+			String fileName = extractFileName(normalizedUrl);
 			byte[] content;
-			try (InputStream inputStream = url.openStream();
+
+			try (InputStream inputStream = connection.getInputStream();
 				 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 				IOUtils.copy(inputStream, outputStream);
 				content = outputStream.toByteArray();
@@ -43,7 +52,7 @@ public class ImageUtil {
 
 			return new CustomMultipartFile(content, fileName, contentType);
 		} catch (IOException e) {
-			log.error("URL을 MultipartFile로 변환하는 데 실패했습니다.");
+			log.error("[Image] URL을 MultipartFile로 변환하는 데 실패했습니다.: {}", imageUrl);
 			throw new ImageException(IMAGE_EXTRACTION_FAILED);
 		}
 	}
@@ -51,9 +60,19 @@ public class ImageUtil {
 	private static String extractFileName(String fileUrl) {
 		try {
 			URL url = new URL(fileUrl);
-			StringBuilder fileName = new StringBuilder(new File(url.getPath()).getName());
 			String query = url.getQuery();
-			if (query != null) {
+			if (query != null && query.contains("fname=")) {
+				for (String param : query.split("&")) {
+					if (param.startsWith("fname=")) {
+						String fnameValue = param.substring("fname=".length());
+						// 디코딩하여 원래의 URL 형태로 복원
+						String decodedFname = URLDecoder.decode(fnameValue, StandardCharsets.UTF_8);
+						return decodedFname.isEmpty() ? "unknown" : decodedFname;
+					}
+				}
+			}
+			StringBuilder fileName = new StringBuilder(new File(url.getPath()).getName());
+			if (query != null && !query.isEmpty()) {
 				for (String param : query.split("&")) {
 					if (param.startsWith("type=")) {
 						fileName.append("?").append(param);
@@ -65,6 +84,13 @@ public class ImageUtil {
 		} catch (Exception e) {
 			return "unknown";
 		}
+	}
+
+	private static String normalizeUrl(String imageUrl) {
+		if (!imageUrl.startsWith("http://") && !imageUrl.startsWith("https://")) {
+			return "https://" + imageUrl;
+		}
+		return imageUrl;
 	}
 
 	// MultipartFile 인터페이스를 구현한 커스텀 클래스

--- a/src/main/java/com/adit/backend/infra/s3/service/AwsS3Service.java
+++ b/src/main/java/com/adit/backend/infra/s3/service/AwsS3Service.java
@@ -45,7 +45,7 @@ public class AwsS3Service {
 			String normalizedUrl = normalizeUrl(imageUrl);
 			MultipartFile file = ImageUtil.convertUrlToMultipartFile(normalizedUrl);
 			String originalFilename = file.getOriginalFilename();
-			String fileName = createFileName(originalFilename, dirName);
+			String fileName = createFileName(originalFilename, dirName, file);
 
 			ObjectMetadata objectMetadata = new ObjectMetadata();
 			objectMetadata.setContentLength(file.getSize());
@@ -74,7 +74,7 @@ public class AwsS3Service {
 			amazonS3.deleteObject(new DeleteObjectRequest(bucket, oldKey));
 			log.info("[S3] 기존 이미지 삭제 완료: key = {}", oldKey);
 			String dirName = extractPathWithoutFileName(oldKey);
-			String newKey = createFileName(newImage.getOriginalFilename(), dirName);
+			String newKey = createFileName(newImage.getOriginalFilename(), dirName, newImage);
 
 			ObjectMetadata metadata = new ObjectMetadata();
 			metadata.setContentType(newImage.getContentType());
@@ -104,16 +104,25 @@ public class AwsS3Service {
 	}
 
 	// 파일명을 난수화하기 위해 UUID를 활용
-	private String createFileName(String fileName, String dirName) {
-		return dirName + "/" + UUID.randomUUID().toString().concat(getFileExtension(fileName));
+	private String createFileName(String fileName, String dirName, MultipartFile file) {
+		return dirName + "/" + UUID.randomUUID().toString().concat(getFileExtension(fileName, file));
 	}
 
 	// "."의 존재 유무만 판단 (잘못된 형식이면 S3Exception 발생)
-	private String getFileExtension(String fileName) {
-		try {
-			return fileName.substring(fileName.lastIndexOf("."));
-		} catch (StringIndexOutOfBoundsException e) {
-			log.error("[S3] 잘못된 파일 형식: 파일명 = {}", fileName);
+	private String getFileExtension(String fileName, MultipartFile file) {
+		int dotIndex = fileName.lastIndexOf(".");
+		if (dotIndex != -1) {
+			return fileName.substring(dotIndex);
+		} else {
+			// 파일명이 확장자가 없으면, MIME 타입 기반으로 확장자를 결정 (예: image/jpeg -> .jpg)
+			String contentType = file.getContentType();
+			if ("image/jpeg".equalsIgnoreCase(contentType)) {
+				return ".jpg";
+			} else if ("image/png".equalsIgnoreCase(contentType)) {
+				return ".png";
+			}
+			// 필요시 다른 MIME 타입도 추가 검증
+			log.error("[S3] 파일명에 확장자가 존재하지 않음: {}", fileName);
 			throw new S3Exception(S3_INVALID_FILE);
 		}
 	}
@@ -135,7 +144,9 @@ public class AwsS3Service {
 	 */
 	private String normalizeUrl(String imageUrl) {
 		if (!imageUrl.startsWith("http://") && !imageUrl.startsWith("https://")) {
-			// 필요에 따라 "https://" 프로토콜이 보장된 브런치스토리 URL 처리
+			if (imageUrl.startsWith("//")) {
+				return "https:" + imageUrl;
+			}
 			return "https://" + imageUrl;
 		}
 		return imageUrl;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 이미지 URL 정규화 기능 추가  
- [x] 브런치스토리 이미지 추출 오류 해결  
- [x] 티스토리 및 브런치스토리 이미지 파일 URL 지원 범위 확장과 파일명 생성 로직 개선

## 💡 자세한 설명

1. **이미지 URL 정규화 기능 추가**  
   - 다양한 이미지 소스(티스토리, 브런치스토리 등)의 URL을 표준화하여 처리할 수 있도록 기능을 추가

2. **브런치스토리 이미지 추출 오류 해결**  
   - 특정 쿼리 내에 담긴 브런치스토리 이미지 URL 정보를 올바르게 추출하도록 수정
   - 테스트용 이미지 업로드 API를 작성 및 검증 

3. **이미지 파일 URL 지원 범위 확장 및 파일명 생성 로직 개선**  
   - 티스토리와 브런치스토리 이미지 URL 지원 범위를 확장하고, 이를 기반으로 파일명을 생성하는 로직을 개선
   - 다양한 이미지 파일 포맷에 대응

## 📗 참고 자료 (선택)
- 내부 커밋 메시지 및 코드 리뷰 기록  
- 관련 테스트 결과 및 이미지 업로드 API 테스트 문서
- close #66

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?  
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?  
- [x] Assignees, Reviewers, Labels 를 등록했나요?  
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?  
- [x] 불필요한 코드는 제거했나요?