### PR TITLE
[Fix] JWT 토큰 검증 로직 개선 

### DIFF
--- a/src/main/java/com/adit/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/AuthService.java
@@ -59,7 +59,8 @@ public class AuthService {
 	//로그인
 	public LoginResponse login(KakaoRequest.AuthDto request, HttpServletResponse response) {
 		try {
-			KakaoResponse.TokenInfoDto kakaoTokenInfo = kakaoOAuthService.requestTokenIssuance(request.code()).getBody();
+			KakaoResponse.TokenInfoDto kakaoTokenInfo = kakaoOAuthService.requestTokenIssuance(request.code())
+				.getBody();
 			OAuth2UserInfo oAuth2UserInfo = kakaoOAuthService.requestOAuth2UserInfo(kakaoTokenInfo.accessToken());
 			UserResponse.InfoDto infoDto = userCommandService.createOrUpdateUser(oAuth2UserInfo);
 

--- a/src/main/java/com/adit/backend/global/security/jwt/enums/TokenStatus.java
+++ b/src/main/java/com/adit/backend/global/security/jwt/enums/TokenStatus.java
@@ -1,0 +1,8 @@
+package com.adit.backend.global.security.jwt.enums;
+
+public enum TokenStatus {
+	VALID,      // 토큰이 유효함
+	EXPIRED,    // 토큰이 만료됨
+	INVALID,    // 토큰 형식이나 서명이 잘못됨
+	NOT_FOUND   // 토큰이 존재하지 않음
+}


### PR DESCRIPTION
## 💡 작업 내용
- JwtTokenProvider에서 AccessToken 검증 시 TokenStatus를 반환하도록 수정  
- 반환된 TokenStatus를 기반으로 필터 체인에서 만료된 토큰 요청을 차단하는 로직 구현

## 💡 자세한 설명
### 1. JwtTokenProvider 수정  
 - AccessToken 검증 시, 토큰의 유효 상태(TokenStatus)를 반환하도록 수정하여 만료된 토큰인 경우 이를 명확히 식별할 수 있도록 한다.  

### 2. 필터 체인 개선  
 - 반환된 TokenStatus를 참고하여, 만료된 토큰일 경우 요청을 즉시 차단하고 적절한 401 Unauthorized 응답 또는 에러 메시지를 전달하도록 필터 체인을 업데이트한다.  

## 📗 참고 자료 (선택)
- 관련 이슈 : close #71

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?  
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?  
- [x] Assignees, Reviewers, Labels 를 등록했나요?  
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?  
- [x] 불필요한 코드는 제거했나요?