### PR TITLE
[Feat] 이미지 업로드 비동기 처리 및 CommonEvent 엔티티 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,6 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-
-
 }
 
 dependencyManagement {

--- a/src/main/java/com/adit/backend/domain/event/entity/CommonEvent.java
+++ b/src/main/java/com/adit/backend/domain/event/entity/CommonEvent.java
@@ -32,7 +32,7 @@ public class CommonEvent extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false)
+	@Column(unique = true, nullable = false)
 	private String name;
 
 	@Column(nullable = false)
@@ -84,6 +84,4 @@ public class CommonEvent extends BaseEntity {
 		if (updateRequest.getMemo() != null)
 			this.memo = updateRequest.getMemo();
 	}
-
-
 }

--- a/src/main/java/com/adit/backend/domain/image/enums/Directory.java
+++ b/src/main/java/com/adit/backend/domain/image/enums/Directory.java
@@ -1,0 +1,18 @@
+package com.adit.backend.domain.image.enums;
+
+public enum Directory {
+	USER("USER/"),
+	PLACE("PLACE"),
+	EVENT("EVENT"),
+	TEST("TEST");
+
+	private final String path;
+
+	Directory(String path) {
+		this.path = path;
+	}
+
+	public String getPath() {
+		return path;
+	}
+}

--- a/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
@@ -56,18 +56,16 @@ public class ImageCommandService {
 
 	// UserPlace에 이미지 연관관계 추가 후 저장
 	public void addImageToUserPlace(PlaceRequestDto request, User user, UserPlace userPlace) {
-		Image userPlaceImage = s3Service.uploadFile(request.imageUrlList(), USER.getPath() + user.getId())
-			.join()
-			.get(0);
-		userPlace.addImage(userPlaceImage);
-		imageRepository.save(userPlaceImage);
+		Image image = s3Service.uploadFile(request.imageUrlList(), USER.getPath() + user.getId()).join().get(0);
+		userPlace.addImage(image);
+		imageRepository.save(image);
 	}
 
 	// CommonPlace에 이미지 연관관계 추가 후 저장
 	public void addImageToCommonPlace(PlaceRequestDto request, CommonPlace commonPlace) {
-		Image commonPlaceImage = s3Service.uploadFile(request.imageUrlList(), PLACE.getPath()).join().get(0);
-		commonPlace.addImage(commonPlaceImage);
-		imageRepository.save(commonPlaceImage);
+		Image image = s3Service.uploadFile(request.imageUrlList(), PLACE.getPath()).join().get(0);
+		commonPlace.addImage(image);
+		imageRepository.save(image);
 	}
 
 	// CommonEvent에 이미지 연관관계 추가 후 저장

--- a/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
@@ -1,5 +1,7 @@
 package com.adit.backend.domain.image.service.command;
 
+import static com.adit.backend.domain.image.enums.Directory.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -9,7 +11,6 @@ import org.springframework.web.multipart.MultipartFile;
 import com.adit.backend.domain.event.dto.request.EventRequestDto;
 import com.adit.backend.domain.event.entity.CommonEvent;
 import com.adit.backend.domain.event.entity.UserEvent;
-import com.adit.backend.domain.event.repository.UserEventRepository;
 import com.adit.backend.domain.image.converter.ImageConverter;
 import com.adit.backend.domain.image.dto.response.ImageResponseDto;
 import com.adit.backend.domain.image.entity.Image;
@@ -18,7 +19,6 @@ import com.adit.backend.domain.image.service.query.ImageQueryService;
 import com.adit.backend.domain.place.dto.request.PlaceRequestDto;
 import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.UserPlace;
-import com.adit.backend.domain.place.repository.CommonPlaceRepository;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.infra.s3.service.AwsS3Service;
 
@@ -31,24 +31,18 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageCommandService {
-	public static final String USER_DIR_PATH = "USER/";
-	public static final String PLACE_DIR_PATH = "PLACE";
-	public static final String EVENT_DIR_PATH = "EVENT";
-	public static final String TEST_DIR_PATH = "TEST";
-	private final CommonPlaceRepository commonPlaceRepository;
 	private final ImageRepository imageRepository;
-	private final UserEventRepository userEventRepository;
 	private final ImageConverter imageConverter;
 	private final AwsS3Service s3Service;
 	private final ImageQueryService imageQueryService;
 
 	public String uploadImage(String url) {
-		return s3Service.uploadFile(List.of(url), TEST_DIR_PATH).get(0).getUrl();
+		return s3Service.uploadFile(List.of(url), TEST.getPath()).join().get(0).getUrl();
 	}
 
 	public ImageResponseDto updateImage(Long imageId, MultipartFile multipartFile) {
 		Image image = imageQueryService.getImageById(imageId);
-		String newImageUrl = s3Service.updateImage(image.getUrl(), multipartFile);
+		String newImageUrl = s3Service.updateImage(image.getUrl(), multipartFile).join();
 		image.updateUrl(newImageUrl);
 		return imageConverter.toResponse(image);
 	}
@@ -62,30 +56,31 @@ public class ImageCommandService {
 
 	// UserPlace에 이미지 연관관계 추가 후 저장
 	public void addImageToUserPlace(PlaceRequestDto request, User user, UserPlace userPlace) {
-		Image userPlaceImage = s3Service.uploadFile(request.imageUrlList(), USER_DIR_PATH + user.getId()).get(0);
+		Image userPlaceImage = s3Service.uploadFile(request.imageUrlList(), USER.getPath() + user.getId())
+			.join()
+			.get(0);
 		userPlace.addImage(userPlaceImage);
 		imageRepository.save(userPlaceImage);
 	}
 
 	// CommonPlace에 이미지 연관관계 추가 후 저장
 	public void addImageToCommonPlace(PlaceRequestDto request, CommonPlace commonPlace) {
-		Image commonPlaceImage = s3Service.uploadFile(request.imageUrlList(), PLACE_DIR_PATH).get(0);
+		Image commonPlaceImage = s3Service.uploadFile(request.imageUrlList(), PLACE.getPath()).join().get(0);
 		commonPlace.addImage(commonPlaceImage);
 		imageRepository.save(commonPlaceImage);
 	}
 
 	// CommonEvent에 이미지 연관관계 추가 후 저장
 	public void addImageToCommonEvent(EventRequestDto request, CommonEvent commonEvent) {
-		Image image = s3Service.uploadFile(request.imageUrlList(), EVENT_DIR_PATH).get(0);
+		Image image = s3Service.uploadFile(request.imageUrlList(), EVENT.getPath()).join().get(0);
 		commonEvent.addImage(image);
 		imageRepository.save(image);
 	}
 
 	// UserEvent에 이미지 연관관계 추가 후 저장
 	public void addImageToUserEvent(EventRequestDto request, User user, UserEvent userEvent) {
-		Image image = s3Service.uploadFile(request.imageUrlList(), USER_DIR_PATH + user.getId()).get(0);
+		Image image = s3Service.uploadFile(request.imageUrlList(), USER.getPath() + user.getId()).join().get(0);
 		userEvent.addImage(image);
 		imageRepository.save(image);
 	}
-
 }

--- a/src/main/java/com/adit/backend/domain/user/entity/User.java
+++ b/src/main/java/com/adit/backend/domain/user/entity/User.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -27,7 +28,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user")
+@Table(
+	name = "user",
+	indexes = @Index(name = "idx_user_email", columnList = "email")
+)
 public class User extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/adit/backend/domain/user/principal/PrincipalDetailsService.java
@@ -27,7 +27,7 @@ public class PrincipalDetailsService implements UserDetailsService {
 	@Override
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 		User user = userQueryService.findUserByEmail(email);
-		log.info("[User] 사용자를 찾았습니다. {}", user.getEmail());
+		log.debug("[User] 사용자를 찾았습니다. {}", user.getEmail());
 		return createPrincipalDetails(user, Collections.emptyMap(), "id");
 	}
 

--- a/src/main/java/com/adit/backend/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/adit/backend/domain/user/service/command/UserCommandService.java
@@ -34,7 +34,7 @@ public class UserCommandService {
 	public UserResponse.InfoDto createOrUpdateUser(OAuth2UserInfo oAuth2UserInfo) {
 		User user = userQueryService.findOrGetUserByOAuthInfo(oAuth2UserInfo);
 		userRepository.save(user);
-		log.info("[User] 유저 저장 완료 email : {}", user.getEmail());
+		log.debug("[User] 유저 저장 완료 email : {}", user.getEmail());
 		return userConverter.InfoDto(user);
 	}
 }

--- a/src/main/java/com/adit/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/adit/backend/global/config/AsyncConfig.java
@@ -1,9 +1,11 @@
 package com.adit.backend.global.config;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -12,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 @Configuration
 @EnableAsync
 @Slf4j
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 	@Bean(name = "crawlingTaskExecutor")
 	public ThreadPoolTaskExecutor crawlingTaskExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -23,6 +25,17 @@ public class AsyncConfig {
 		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy()); // 초과 요청에 대한 정책
 		executor.setWaitForTasksToCompleteOnShutdown(true); // 시스템 종료 시 진행 중인 작업 완료 대기
 		executor.setAwaitTerminationSeconds(60); // 최대 종료 대기 시간
+		executor.initialize();
+		return executor;
+	}
+
+	@Bean(name = "imageUploadExecutor")
+	public Executor imageUploadExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(10); // 기본적으로 실행할 스레드 수
+		executor.setMaxPoolSize(20); // 최대 스레드 수
+		executor.setQueueCapacity(50); // 대기 중인 작업 큐의 크기
+		executor.setThreadNamePrefix("ImageUploadExecutor-"); // 스레드 이름 접두사
 		executor.initialize();
 		return executor;
 	}

--- a/src/main/java/com/adit/backend/global/util/ImageUtil.java
+++ b/src/main/java/com/adit/backend/global/util/ImageUtil.java
@@ -1,22 +1,10 @@
 package com.adit.backend.global.util;
 
-import static com.adit.backend.global.error.GlobalErrorCode.*;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-
-import org.apache.tomcat.util.http.fileupload.IOUtils;
-import org.springframework.web.multipart.MultipartFile;
-
-import com.adit.backend.domain.image.exception.ImageException;
+import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,41 +15,7 @@ public class ImageUtil {
 	public static final String HTTPS = "https://";
 	public static final String HTTP = "http://";
 
-	/**
-	 * 주어진 이미지 URL을 읽어 MultipartFile로 변환하여 반환한다.
-	 *
-	 * @param imageUrl 이미지의 URL 문자열
-	 * @return 변환된 MultipartFile 객체
-	 * @throws Exception 이미지 읽기 및 변환 중 예외 발생 시
-	 */
-	// URL로부터 데이터를 읽어와서 CustomMultipartFile로 변환하여 반환
-	public static MultipartFile convertUrlToMultipartFile(String imageUrl) {
-		try {
-			// URL에 프로토콜이 누락된 경우 "https://"를 추가함
-			String normalizedUrl = normalizeUrl(imageUrl);
-			URL url = new URL(normalizedUrl);
-			URLConnection connection = url.openConnection();
-			connection.setConnectTimeout(5000);
-			connection.setReadTimeout(5000);
-			String contentType = connection.getContentType();
-
-			String fileName = extractFileName(normalizedUrl);
-			byte[] content;
-
-			try (InputStream inputStream = connection.getInputStream();
-				 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-				IOUtils.copy(inputStream, outputStream);
-				content = outputStream.toByteArray();
-			}
-
-			return new CustomMultipartFile(content, fileName, contentType);
-		} catch (IOException e) {
-			log.error("[Image] URL을 MultipartFile로 변환하는 데 실패했습니다.: {}", imageUrl);
-			throw new ImageException(IMAGE_EXTRACTION_FAILED);
-		}
-	}
-
-	private static String extractFileName(String fileUrl) {
+	public static String extractFileName(String fileUrl) {
 		try {
 			URL url = new URL(fileUrl);
 			String query = url.getQuery();
@@ -80,7 +34,7 @@ public class ImageUtil {
 		}
 	}
 
-	private static String normalizeUrl(String imageUrl) {
+	public static String normalizeUrl(String imageUrl) {
 		if (imageUrl.contains(FILE_NAME_PARAM)) {
 			String fileName = imageUrl.substring(imageUrl.indexOf(FILE_NAME_PARAM) + FILE_NAME_PARAM.length());
 			fileName = fileName.contains("&") ? fileName.substring(0, fileName.indexOf("&")) : fileName;
@@ -98,56 +52,41 @@ public class ImageUtil {
 		return imageUrl;
 	}
 
-	// MultipartFile 인터페이스를 구현한 커스텀 클래스
-	public static class CustomMultipartFile implements MultipartFile {
-		private final byte[] content;
-		private final String fileName;
-		private final String contentType;
-
-		public CustomMultipartFile(byte[] content, String fileName, String contentType) {
-			this.content = content;
-			this.fileName = fileName;
-			this.contentType = contentType;
+	public static String extractPathWithoutFileName(String oldKey) {
+		int lastSlashIndex = oldKey.lastIndexOf('/');
+		if (lastSlashIndex != -1) {
+			return oldKey.substring(0, lastSlashIndex);
 		}
+		return oldKey;
+	}
 
-		@Override
-		public String getName() {
-			return fileName;
+	// "."의 존재 유무만 판단 (잘못된 형식이면 S3Exception 발생)
+	public static String getFileExtension(String fileName, String contentType) {
+		int dotIndex = fileName.lastIndexOf(".");
+		if (dotIndex != -1) {
+			return fileName.substring(dotIndex);
+		} else {
+			if (contentType != null) {
+				switch (contentType.toLowerCase()) {
+					case "image/jpeg":
+						return ".jpg";
+					case "image/png":
+						return ".png";
+					case "image/gif":
+						return ".gif";
+					// 필요한 경우 추가 MIME 타입 처리
+					default:
+						log.warn("[S3] 인식되지 않은 MIME 타입: {}. 기본 확장자(.jpg)를 사용합니다.", contentType);
+						return ".jpg";
+				}
+			} else {
+				log.warn("[S3] 콘텐츠 타입을 확인할 수 없습니다.");
+				return ".jpg";
+			}
 		}
+	}
 
-		@Override
-		public String getOriginalFilename() {
-			return fileName;
-		}
-
-		@Override
-		public String getContentType() {
-			return contentType;
-		}
-
-		@Override
-		public boolean isEmpty() {
-			return content == null || content.length == 0;
-		}
-
-		@Override
-		public long getSize() {
-			return content.length;
-		}
-
-		@Override
-		public byte[] getBytes() {
-			return content;
-		}
-
-		@Override
-		public InputStream getInputStream() {
-			return new ByteArrayInputStream(content);
-		}
-
-		@Override
-		public void transferTo(File dest) throws IOException, IllegalStateException {
-			Files.write(dest.toPath(), content);
-		}
+	public static String createFileName(String originalFileName, String dirName, String contentType) {
+		return dirName + "/" + UUID.randomUUID() + getFileExtension(originalFileName, contentType);
 	}
 }


### PR DESCRIPTION
## 💡 작업 내용
- 이미지 업로드 및 업데이트 비동기 처리 추가  

## 💡 자세한 설명

1. **이미지 업로드 및 업데이트 비동기 처리**  
   - 로그 추적 결과 S3 이미지 업로드 과정에서 응답 속도 개선이 필요하단 것을 알게 되었습니다.
   - 이미지 업로드 및 업데이트 작업을 비동기로 처리하도록 개선 <br>
   - [이전 응답](#67)
   ![image](https://github.com/user-attachments/assets/89e86490-1cd1-45a7-a01b-b551669a3949)
   - 개선 이후 (8s -> 4s : **100% 성능 개선 진행 완료**)
   ![image](https://github.com/user-attachments/assets/ccf20a2a-346f-4820-b96c-34e7b747fef4)
   - 여러 조건을 테스트 한 결과 인스타그램 플랫폼에서 추출한 이미지 url을 업로드하는 과정에서 평균적으로 2~4s 응답속도가 나오고 있습니다.
   - 블로그 글 형식에서 추출한 이미지 url 업로드는 모든 결과 0.8s 이내에 처리되고 있습니다.
   - 이슈를 진행했지만 아직 개선점이 더 필요할 것 같습니다.
   - 이미지 파일 형식과 파일 크기가 성능에 영향을 주고 있는 듯 하여 알림 기능개발 이후 이미지 리사이징을 초점에 맞추어 다음 이슈로 진행해보겠습니다.  
  

2. **사용자 Index 추가**  
   - 데이터베이스에서 사용자 검색 성능을 개선하기 위해 사용자 테이블에 Index를 추가

3. **CommonEvent 엔티티 개선**  
   - CommonEvent 엔티티의 name 필드를 고유하게 설정하여 중복 데이터 삽입을 방지

## 📗 참고 자료 (선택)
- solved #68
- #67
## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?  
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?  
- [x] Assignees, Reviewers, Labels 를 등록했나요?  
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?  
- [x] 불필요한 코드는 제거했나요?