### PR TITLE
[Fix] EC2 배포 시 기존 프로세스 종료 미완료 문제 개선

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -8,7 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -32,8 +33,6 @@ jobs:
           echo "SERVER_BASE_URL=${{ secrets.SERVER_BASE_URL }}" >> .env
           echo "SCRAPER_API_TOKEN=${{ secrets.SCRAPER_API_TOKEN }}" >> .env
           echo "SCRAPER_BASE_URL=${{ secrets.SCRAPER_BASE_URL }}" >> .env
-          echo "SCRAPER_OUTPUT_URL=${{ secrets.SCRAPER_OUTPUT_URL }}" >> .env
-          echo "SCRAPER_OUTPUT_URL=${{ secrets.SCRAPER_OUTPUT_URL }}" >> .env
           echo "SCRAPER_OUTPUT_URL=${{ secrets.SCRAPER_OUTPUT_URL }}" >> .env
           echo "S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }}" >> .env
           echo "S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }}" >> .env
@@ -89,35 +88,42 @@ jobs:
           echo "S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}" >> .env
           echo "FRONT_LOCAL_URL=${{ secrets.FRONT_LOCAL_URL }}" >> .env
           echo "SPRING_AI_MAX_TOKENS=${{ secrets.SPRING_AI_MAX_TOKENS }}" >> .env
+        shell: bash
+
       - name: Deploy to EC2
         env:
           EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
           EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
           EC2_HOST: ${{ secrets.EC2_HOST }}
         run: |
+          # SSH 키 파일 생성 및 권한 설정
           echo "$EC2_SSH_KEY" > private_key.pem
           chmod 600 private_key.pem
-          
+
+          # .env 파일 전송
           scp -i private_key.pem -o StrictHostKeyChecking=no .env $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/.env
-          
+
+          # 빌드 결과물 JAR 파일 확인 및 전송
           jar_file=$(find build/libs -name '*.jar' ! -name '*plain.jar' | head -n 1)
           if [ -z "$jar_file" ]; then
             echo "JAR file not found"
             exit 1
           fi
-          
           scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/AditServer.jar
-          
+
+          # 기존 애플리케이션 종료 후, 30초 대기 후 신규 실행
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USERNAME@$EC2_HOST "
             pid=\$(pgrep java || echo '')
             if [ ! -z \"\$pid\" ]; then
+              echo \"Stopping running application...\"
               kill -15 \$pid
-              sleep 10
+              echo \"Waiting 30 seconds for graceful shutdown...\"
+              sleep 30
             fi
-          
             cd /home/$EC2_USERNAME
             nohup java -jar AditServer.jar > app.log 2>&1 &
             echo 'Application started'
           "
-          
+
+          # SSH 키 파일 삭제
           rm -f private_key.pem

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,8 @@
 # 서버환경입니다. application-dev.yml
+
+server:
+  shutdown: graceful
+
 spring:
   config:
     import: optional:file:/home/${EC2_USERNAME}/.env[.properties]
@@ -18,8 +22,9 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
-
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
 redirect:
   url: ${FRONT_LOCAL_URL}/login/kakao


### PR DESCRIPTION
## 💡 작업 내용
- [x] 애플리케이션 설정 파일에 Graceful Shutdown 설정 추가
- [x] 배포 스크립트에 기존 프로세스 종료 후 30초 대기 로직 적용

## 💡 자세한 설명
**Graceful Shutdown 설정 추가**  
- 애플리케이션 종료 시 리소스(예: Tomcat, Redis 등)가 정상적으로 정리되도록 하기 위해 graceful shutdown을 적용

**배포 스크립트 수정**  
- 기존 Java 프로세스 종료 후 충분한 대기 시간을 두어 애플리케이션의 자원이 완전히 해제된 후 새 JAR 파일이 실행되도록 수정

**데이터베이스 스키마 생성 규칙 변경**
- 현재 버전 이후로 dev application 설정 스키마 생성 규칙이 update로 변경되었습니다. 이후 커밋, PR요청시 체크 부탁드립니다!

## 📗 참고 자료 (선택)
- solved #83 

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] Assignees, Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 수정했나요?
- [x] 불필요한 코드는 제거했나요?