### PR TITLE
[Feat] SSE + Redis pub/sub를 이용한 알림 기능 구현 완료

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -38,6 +38,7 @@ jobs:
           echo "S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }}" >> .env
           echo "S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}" >> .env
           echo "FRONT_LOCAL_URL=${{ secrets.FRONT_LOCAL_URL }}" >> .env
+          echo "FRONT_BASE_URL=${{ secrets.FRONT_BASE_URL }}" >> .env
           echo "SPRING_AI_MAX_TOKENS=${{ secrets.SPRING_AI_MAX_TOKENS }}" >> .env
         shell: bash
 
@@ -87,6 +88,7 @@ jobs:
           echo "S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }}" >> .env
           echo "S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}" >> .env
           echo "FRONT_LOCAL_URL=${{ secrets.FRONT_LOCAL_URL }}" >> .env
+          echo "FRONT_BASE_URL=${{ secrets.FRONT_BASE_URL }}" >> .env
           echo "SPRING_AI_MAX_TOKENS=${{ secrets.SPRING_AI_MAX_TOKENS }}" >> .env
         shell: bash
 

--- a/src/main/java/com/adit/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/AuthService.java
@@ -144,8 +144,8 @@ public class AuthService {
 		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
 		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
 		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
-		//cookie.setSecure(true);
-		//cookie.setHttpOnly(true);
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
 		response.addCookie(cookie);
 		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
 	}

--- a/src/main/java/com/adit/backend/domain/event/entity/UserEvent.java
+++ b/src/main/java/com/adit/backend/domain/event/entity/UserEvent.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import com.adit.backend.domain.event.dto.request.EventUpdateRequestDto;
 import com.adit.backend.domain.image.entity.Image;
-import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.global.entity.BaseEntity;
 
@@ -53,12 +52,8 @@ public class UserEvent extends BaseEntity {
 
 	private LocalDateTime startDate;
 	private LocalDateTime endDate;
-
 	private String memo;
 	private Boolean visited;
-
-	@OneToMany(mappedBy = "userEvent", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Notification> notifications = new ArrayList<>();
 
 	@OneToMany(mappedBy = "userEvent", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Image> images = new ArrayList<>();
@@ -77,11 +72,6 @@ public class UserEvent extends BaseEntity {
 	}
 
 	// 연관관계 메서드
-	public void addNotification(Notification notification) {
-		this.notifications.add(notification);
-		notification.setUserEvent(this);
-	}
-
 	public void addImage(Image image) {
 		this.images.add(image);
 		image.assignEvent(this);

--- a/src/main/java/com/adit/backend/domain/image/dto/response/ImageResponseDto.java
+++ b/src/main/java/com/adit/backend/domain/image/dto/response/ImageResponseDto.java
@@ -10,7 +10,6 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
-import lombok.Getter;
 
 /**
  * DTO for {@link Image}
@@ -19,7 +18,6 @@ import lombok.Getter;
 public record ImageResponseDto(@NotNull(message = "이미지 ID는 null일 수 없습니다.") Long id,
 							   @Nullable CommonPlace commonPlace,
 							   @Nullable UserPlace userPlace,
-
 							   @Nullable UserEvent userEvent,
 							   @Nullable CommonEvent commonEvent,
 							   @NotBlank(message = "이미지 주소는 공백일 수 없습니다.") String url) {

--- a/src/main/java/com/adit/backend/domain/notification/constants/Channel.java
+++ b/src/main/java/com/adit/backend/domain/notification/constants/Channel.java
@@ -1,0 +1,5 @@
+package com.adit.backend.domain.notification.constants;
+
+public class Channel {
+	public static final String CHANNEL_PREFIX = "channel:";
+}

--- a/src/main/java/com/adit/backend/domain/notification/constants/MsgFormat.java
+++ b/src/main/java/com/adit/backend/domain/notification/constants/MsgFormat.java
@@ -1,0 +1,6 @@
+package com.adit.backend.domain.notification.constants;
+
+public class MsgFormat {
+
+	public final static String SUBSCRIBE = "Event Subscribed.";
+}

--- a/src/main/java/com/adit/backend/domain/notification/controller/DemoDayController.java
+++ b/src/main/java/com/adit/backend/domain/notification/controller/DemoDayController.java
@@ -1,0 +1,47 @@
+package com.adit.backend.domain.notification.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.adit.backend.domain.notification.service.NotificationDemoDayService;
+import com.adit.backend.global.common.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/demo")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Tag(name = "데모데이 API", description = "데모데이를 위한 API 입니다 다들 고생하셨습니다 :D")
+
+public class DemoDayController {
+
+	private final NotificationDemoDayService notificationDemoDayService;
+
+	@PostMapping("/duration")
+	@Operation(summary = "데모데이 누락 기간 알림", description = "원영이형한테 보내봐요!")
+	public ResponseEntity<ApiResponse<String>> sendDuration() {
+		notificationDemoDayService.sendDurationNotification();
+		return ResponseEntity.ok(ApiResponse.success("아마도 잘 보내졌을거에요!"));
+	}
+
+	@PostMapping("/unvisited")
+	@Operation(summary = "데모데이 미방문 장소 알림", description = "원영이형한테 보내봐요!")
+	public ResponseEntity<ApiResponse<String>> sendUnvisited() {
+		notificationDemoDayService.sendUnvisitedNotification();
+		return ResponseEntity.ok(ApiResponse.success("아마도 잘 보내졌을거에요!"));
+	}
+
+	@PostMapping("/start")
+	@Operation(summary = "데모데이 이벤트 시작 알림", description = "원영이형한테 보내봐요!")
+	public ResponseEntity<ApiResponse<String>> sendStartNotification() {
+		notificationDemoDayService.sendStartNotification();
+		return ResponseEntity.ok(ApiResponse.success("아마도 잘 보내졌을거에요!"));
+	}
+
+
+}

--- a/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
@@ -14,7 +14,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.adit.backend.domain.notification.converter.NotificationConverter;
 import com.adit.backend.domain.notification.dto.NotificationResponse;
-import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.notification.service.command.NotificationCommandService;
 import com.adit.backend.domain.notification.service.query.NotificationQueryService;
 import com.adit.backend.domain.user.entity.User;
@@ -49,7 +48,7 @@ public class NotificationController {
 
 	@Operation(summary = "카테고리별 알람 리스트 조회", description = "최근 일주일 내의 모은 알람 내역중 카테고리 기반 내역 반환")
 	@GetMapping("/category")
-	public ResponseEntity<ApiResponse<List<Notification>>> getNotificationsByCategory(
+	public ResponseEntity<ApiResponse<List<NotificationResponse>>> getNotificationsByCategory(
 		@AuthenticationPrincipal(expression = "user") User user,
 		@RequestParam String category) {
 		return ResponseEntity.ok(

--- a/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
@@ -1,0 +1,52 @@
+package com.adit.backend.domain.notification.controller;
+
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.adit.backend.domain.notification.dto.NotificationResponse;
+import com.adit.backend.domain.notification.service.command.NotificationCommandService;
+import com.adit.backend.domain.notification.service.query.NotificationQueryService;
+import com.adit.backend.domain.user.entity.User;
+import com.adit.backend.global.common.ApiResponse;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/notification")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationController {
+
+	private final NotificationCommandService notificationCommandService;
+	private final NotificationQueryService notificationQueryService;
+
+	// 응답 시 MIME 타입을 text/event-stream으로 보내야한다.
+	@GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public ResponseEntity<SseEmitter> subscribe(@AuthenticationPrincipal(expression = "user") User user) {
+		return ResponseEntity.ok(notificationCommandService.subscribe(user.getEmail()));
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<NotificationResponse>>> notifications(@AuthenticationPrincipal(expression = "user") User user) {
+		return ResponseEntity.ok(ApiResponse.success(notificationQueryService.getAllNotifications(user.getEmail())));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<Void> redirect(@PathVariable Long id) {
+		URI redirectUri = notificationCommandService.getRedirectUri(id);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(redirectUri);
+		return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
@@ -1,25 +1,27 @@
 package com.adit.backend.domain.notification.controller;
 
-import java.net.URI;
-import java.util.List;
+	import java.util.List;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.adit.backend.domain.notification.converter.NotificationConverter;
 import com.adit.backend.domain.notification.dto.NotificationResponse;
+import com.adit.backend.domain.notification.enums.NotificationType;
+import com.adit.backend.domain.notification.event.NotificationEvent;
 import com.adit.backend.domain.notification.service.command.NotificationCommandService;
 import com.adit.backend.domain.notification.service.query.NotificationQueryService;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.global.common.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -30,23 +32,38 @@ public class NotificationController {
 
 	private final NotificationCommandService notificationCommandService;
 	private final NotificationQueryService notificationQueryService;
+	private final NotificationConverter notificationConverter;
 
-	// 응답 시 MIME 타입을 text/event-stream으로 보내야한다.
+	@Operation(summary = "알람 sse 구독 및 누락 알람 수신", description = "알람 sse 구독, 마지막 이벤트 ID를 기반으로 누락된 알람 수신")
 	@GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-	public ResponseEntity<SseEmitter> subscribe(@AuthenticationPrincipal(expression = "user") User user) {
-		return ResponseEntity.ok(notificationCommandService.subscribe(user.getEmail()));
+	public ResponseEntity<SseEmitter> subscribe(@AuthenticationPrincipal(expression = "user") User user,
+		@RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+		return ResponseEntity.ok(notificationCommandService.subscribe(user.getEmail(), lastEventId));
 	}
 
+	@Operation(summary = "알람 리스트 수신", description = "최근 일주일 내의 모은 알람 내역을 반환")
 	@GetMapping
-	public ResponseEntity<ApiResponse<List<NotificationResponse>>> notifications(@AuthenticationPrincipal(expression = "user") User user) {
-		return ResponseEntity.ok(ApiResponse.success(notificationQueryService.getAllNotifications(user.getEmail())));
+	public ResponseEntity<ApiResponse<List<NotificationResponse>>> notifications(
+		@AuthenticationPrincipal(expression = "user") User user) {
+		return ResponseEntity.ok(ApiResponse.success(notificationQueryService.getRecentNotifications(user.getEmail())
+			.stream()
+			.map(notificationConverter::toResponse)
+			.toList()));
 	}
 
-	@GetMapping("/{id}")
-	public ResponseEntity<Void> redirect(@PathVariable Long id) {
-		URI redirectUri = notificationCommandService.getRedirectUri(id);
-		HttpHeaders headers = new HttpHeaders();
-		headers.setLocation(redirectUri);
-		return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
+	@PostMapping("/test")
+	public ResponseEntity<ApiResponse<String>> sendTestNotification(
+		@AuthenticationPrincipal(expression = "user") User user) {
+		// 테스트용 더미 알림 이벤트 생성
+		NotificationEvent testEvent = NotificationEvent.builder()
+			.userEmail(user.getEmail())
+			.message("Test notification from server.")
+			.notificationType(NotificationType.FRIEND_SAVED_MY_PLACE)  // 테스트용 알림 타입 선택
+			.build();
+
+		// 알림 발송 (내부에서 DB 저장 및 Redis를 통한 SSE 브로드캐스트 수행)
+		notificationCommandService.sendNotification(testEvent);
+
+		return ResponseEntity.ok(ApiResponse.success("Test notification sent successfully."));
 	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/adit/backend/domain/notification/controller/NotificationController.java
@@ -54,4 +54,12 @@ public class NotificationController {
 		return ResponseEntity.ok(
 			ApiResponse.success(notificationQueryService.getNotificationsByCategory(user, category)));
 	}
+
+	@Operation(summary = "알람 sse 구독 취소", description = "SSE 연결을 종료하고 구독을 취소합니다")
+	@GetMapping("/unsubscribe")
+	public ResponseEntity<ApiResponse<Void>> unsubscribe(@AuthenticationPrincipal(expression = "user") User user) {
+		notificationCommandService.unsubscribe(user.getEmail());
+		return ResponseEntity.noContent().build();
+	}
+
 }

--- a/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,29 @@
+package com.adit.backend.domain.notification.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.adit.backend.domain.notification.dto.NotificationResponse;
+import com.adit.backend.domain.notification.entity.Notification;
+import com.adit.backend.domain.notification.enums.NotificationType;
+
+@Component
+public class NotificationConverter {
+
+	public Notification toEntity(String message, NotificationType notificationType, String relatedUri) {
+		return Notification.builder()
+			.message(message)
+			.notificationType(notificationType)
+			.relatedUri(relatedUri).
+			build();
+	}
+
+	public NotificationResponse toResponse(Notification notification) {
+		return NotificationResponse
+			.builder()
+			.message(notification.getMessage())
+			.notificationType(notification.getNotificationType())
+			.relatedUri(notification.getRelatedUri())
+			.isRead(notification.isRead())
+			.build();
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
@@ -13,6 +13,7 @@ public class NotificationConverter {
 		return Notification.builder()
 			.message(message)
 			.notificationType(notificationType)
+			.category(notificationType.getCategory())
 			.build();
 	}
 
@@ -21,7 +22,9 @@ public class NotificationConverter {
 			.builder()
 			.message(notification.getMessage())
 			.notificationType(notification.getNotificationType())
+			.category(notification.getNotificationType().getCategory())
 			.isRead(notification.isRead())
+			.createdAt(notification.getCreatedAt())
 			.build();
 	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
@@ -9,12 +9,11 @@ import com.adit.backend.domain.notification.enums.NotificationType;
 @Component
 public class NotificationConverter {
 
-	public Notification toEntity(String message, NotificationType notificationType, String relatedUri) {
+	public Notification toEntity(String message, NotificationType notificationType) {
 		return Notification.builder()
 			.message(message)
 			.notificationType(notificationType)
-			.relatedUri(relatedUri).
-			build();
+			.build();
 	}
 
 	public NotificationResponse toResponse(Notification notification) {
@@ -22,7 +21,6 @@ public class NotificationConverter {
 			.builder()
 			.message(notification.getMessage())
 			.notificationType(notification.getNotificationType())
-			.relatedUri(notification.getRelatedUri())
 			.isRead(notification.isRead())
 			.build();
 	}

--- a/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/adit/backend/domain/notification/converter/NotificationConverter.java
@@ -14,6 +14,7 @@ public class NotificationConverter {
 			.message(message)
 			.notificationType(notificationType)
 			.category(notificationType.getCategory())
+			.isRead(false)
 			.build();
 	}
 
@@ -24,7 +25,7 @@ public class NotificationConverter {
 			.notificationType(notification.getNotificationType())
 			.category(notification.getNotificationType().getCategory())
 			.isRead(notification.isRead())
-			.createdAt(notification.getCreatedAt())
+			.createdAt(notification.getCreatedAt().toLocalDate().toString())
 			.build();
 	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/converter/NotificationEventConverter.java
+++ b/src/main/java/com/adit/backend/domain/notification/converter/NotificationEventConverter.java
@@ -1,0 +1,77 @@
+package com.adit.backend.domain.notification.converter;
+
+import static com.adit.backend.domain.notification.enums.NotificationType.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.adit.backend.domain.event.entity.UserEvent;
+import com.adit.backend.domain.notification.enums.NotificationType;
+import com.adit.backend.domain.notification.event.NotificationEvent;
+import com.adit.backend.domain.place.entity.UserPlace;
+import com.adit.backend.domain.user.entity.Friendship;
+import com.adit.backend.domain.user.entity.User;
+
+@Component
+public class NotificationEventConverter {
+
+	private NotificationEvent createNotificationEvent(String userEmail, NotificationType type, String message) {
+		return NotificationEvent.builder()
+			.userEmail(userEmail)
+			.category(type.getCategory())
+			.notificationType(type)
+			.message(message)
+			.build();
+	}
+
+	/*ANNOUNCEMENT : Not Defined*/
+
+	/* PLACE_UNVISITED */
+	public NotificationEvent toUnvisitedEvent(UserPlace userPlace) {
+		String message = String.format("아직 '%s'에 방문하지 않으셨나요?", userPlace.getCommonPlace().getPlaceName());
+		return createNotificationEvent(userPlace.getUser().getEmail(), PLACE_UNVISITED, message);
+	}
+
+	/* EVENT_START_SOON */
+	public NotificationEvent toStartEvent(UserEvent userEvent, int remainingDays) {
+		String message = String.format("'%s'이 %d일 뒤 시작해요!", userEvent.getName(), remainingDays);
+		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_START_SOON, message);
+	}
+
+	/* EVENT_DURATION_MISSING */
+	public NotificationEvent toMissingEvent(UserEvent userEvent) {
+		String message = String.format("'%s' 기간을 아직 입력하지 않았어요!", userEvent.getName());
+		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_DURATION_MISSING, message);
+	}
+
+	/* EVENT_DURATION_MISSING - 복수 이벤트 옵션 */
+	public NotificationEvent toMultipleMissingEvent(List<UserEvent> userEvents) {
+		if (userEvents == null || userEvents.isEmpty()) {
+			throw new IllegalArgumentException("이벤트 리스트에 하나 이상의 요소가 존재해야 합니다.");
+		}
+		String primaryEventName = userEvents.get(0).getName();
+		int remainingCount = userEvents.size() - 1;
+		String message = String.format("'%s'외 %d개의 이벤트 기간을 아직 입력하지 않았어요!", primaryEventName, remainingCount);
+		return createNotificationEvent(userEvents.get(0).getUser().getEmail(), EVENT_DURATION_MISSING, message);
+	}
+
+	/* FRIEND_REQUEST_RECEIVED */
+	public NotificationEvent toRequestEvent(Friendship friendship) {
+		String message = String.format("%s님이 친구 맺기를 요청했어요!", friendship.getFromUser().getNickname());
+		return createNotificationEvent(friendship.getToUser().getEmail(), FRIEND_REQUEST_RECEIVED, message);
+	}
+
+	/* FRIEND_REQUEST_ACCEPTED */
+	public NotificationEvent toAcceptEvent(Friendship friendship) {
+		String message = String.format("%s님이 친구 맺기를 수락했어요!", friendship.getToUser().getNickname());
+		return createNotificationEvent(friendship.getFromUser().getEmail(), FRIEND_REQUEST_ACCEPTED, message);
+	}
+
+	/* FRIEND_SAVED_MY_PLACE */
+	public NotificationEvent toSavedEvent(UserPlace friendPlace, User user) {
+		String message = String.format("%s님도 '%s'를 저장했어요!", friendPlace.getUser().getNickname(),
+			friendPlace.getCommonPlace().getPlaceName());
+		return createNotificationEvent(user.getEmail(), FRIEND_SAVED_MY_PLACE, message);
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/converter/NotificationEventConverter.java
+++ b/src/main/java/com/adit/backend/domain/notification/converter/NotificationEventConverter.java
@@ -13,15 +13,18 @@ import com.adit.backend.domain.place.entity.UserPlace;
 import com.adit.backend.domain.user.entity.Friendship;
 import com.adit.backend.domain.user.entity.User;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Component
+@Slf4j
 public class NotificationEventConverter {
 
-	private NotificationEvent createNotificationEvent(String userEmail, NotificationType type, String message) {
+	private NotificationEvent createNotificationEvent(String userEmail, NotificationType type, String content) {
 		return NotificationEvent.builder()
 			.userEmail(userEmail)
 			.category(type.getCategory())
 			.notificationType(type)
-			.message(message)
+			.content(content)
 			.build();
 	}
 
@@ -29,20 +32,20 @@ public class NotificationEventConverter {
 
 	/* PLACE_UNVISITED */
 	public NotificationEvent toUnvisitedEvent(UserPlace userPlace) {
-		String message = String.format("아직 '%s'에 방문하지 않으셨나요?", userPlace.getCommonPlace().getPlaceName());
-		return createNotificationEvent(userPlace.getUser().getEmail(), PLACE_UNVISITED, message);
+		String content = String.format("아직 '%s'에 방문하지 않으셨나요?", userPlace.getCommonPlace().getPlaceName());
+		return createNotificationEvent(userPlace.getUser().getEmail(), PLACE_UNVISITED, content);
 	}
 
 	/* EVENT_START_SOON */
 	public NotificationEvent toStartEvent(UserEvent userEvent, int remainingDays) {
-		String message = String.format("'%s'이 %d일 뒤 시작해요!", userEvent.getName(), remainingDays);
-		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_START_SOON, message);
+		String content = String.format("'%s'이 %d일 뒤 시작해요!", userEvent.getName(), remainingDays);
+		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_START_SOON, content);
 	}
 
 	/* EVENT_DURATION_MISSING */
 	public NotificationEvent toMissingEvent(UserEvent userEvent) {
-		String message = String.format("'%s' 기간을 아직 입력하지 않았어요!", userEvent.getName());
-		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_DURATION_MISSING, message);
+		String content = String.format("'%s' 기간을 아직 입력하지 않았어요!", userEvent.getName());
+		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_DURATION_MISSING, content);
 	}
 
 	/* EVENT_DURATION_MISSING - 복수 이벤트 옵션 */
@@ -52,26 +55,27 @@ public class NotificationEventConverter {
 		}
 		String primaryEventName = userEvents.get(0).getName();
 		int remainingCount = userEvents.size() - 1;
-		String message = String.format("'%s'외 %d개의 이벤트 기간을 아직 입력하지 않았어요!", primaryEventName, remainingCount);
-		return createNotificationEvent(userEvents.get(0).getUser().getEmail(), EVENT_DURATION_MISSING, message);
+		String content = String.format("'%s'외 %d개의 이벤트 기간을 아직 입력하지 않았어요!", primaryEventName, remainingCount);
+		return createNotificationEvent(userEvents.get(0).getUser().getEmail(), EVENT_DURATION_MISSING, content);
 	}
 
 	/* FRIEND_REQUEST_RECEIVED */
 	public NotificationEvent toRequestEvent(Friendship friendship) {
-		String message = String.format("%s님이 친구 맺기를 요청했어요!", friendship.getFromUser().getNickname());
-		return createNotificationEvent(friendship.getToUser().getEmail(), FRIEND_REQUEST_RECEIVED, message);
+		log.info("친구 요청 알림 생성");
+		String content = String.format("%s님이 친구 맺기를 요청했어요!", friendship.getFromUser().getNickname());
+		return createNotificationEvent(friendship.getToUser().getEmail(), FRIEND_REQUEST_RECEIVED, content);
 	}
 
 	/* FRIEND_REQUEST_ACCEPTED */
 	public NotificationEvent toAcceptEvent(Friendship friendship) {
-		String message = String.format("%s님이 친구 맺기를 수락했어요!", friendship.getToUser().getNickname());
-		return createNotificationEvent(friendship.getFromUser().getEmail(), FRIEND_REQUEST_ACCEPTED, message);
+		String content = String.format("%s님이 친구 맺기를 수락했어요!", friendship.getToUser().getNickname());
+		return createNotificationEvent(friendship.getFromUser().getEmail(), FRIEND_REQUEST_ACCEPTED, content);
 	}
 
 	/* FRIEND_SAVED_MY_PLACE */
 	public NotificationEvent toSavedEvent(UserPlace friendPlace, User user) {
-		String message = String.format("%s님도 '%s'를 저장했어요!", friendPlace.getUser().getNickname(),
+		String content = String.format("%s님도 '%s'를 저장했어요!", friendPlace.getUser().getNickname(),
 			friendPlace.getCommonPlace().getPlaceName());
-		return createNotificationEvent(user.getEmail(), FRIEND_SAVED_MY_PLACE, message);
+		return createNotificationEvent(user.getEmail(), FRIEND_SAVED_MY_PLACE, content);
 	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,11 @@
+package com.adit.backend.domain.notification.dto;
+
+import com.adit.backend.domain.notification.enums.NotificationType;
+
+import lombok.Builder;
+
+@Builder
+public record NotificationResponse(String message, NotificationType notificationType, String relatedUri,
+								   boolean isRead) {
+}
+

--- a/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
@@ -1,10 +1,16 @@
 package com.adit.backend.domain.notification.dto;
 
+import java.time.LocalDateTime;
+
 import com.adit.backend.domain.notification.enums.NotificationType;
 
 import lombok.Builder;
 
 @Builder
-public record NotificationResponse(String message, NotificationType notificationType, boolean isRead) {
+public record NotificationResponse(String message,
+								   String category,
+								   NotificationType notificationType,
+								   LocalDateTime createdAt,
+								   boolean isRead) {
 }
 

--- a/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
@@ -5,7 +5,6 @@ import com.adit.backend.domain.notification.enums.NotificationType;
 import lombok.Builder;
 
 @Builder
-public record NotificationResponse(String message, NotificationType notificationType, String relatedUri,
-								   boolean isRead) {
+public record NotificationResponse(String message, NotificationType notificationType, boolean isRead) {
 }
 

--- a/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/adit/backend/domain/notification/dto/NotificationResponse.java
@@ -1,7 +1,5 @@
 package com.adit.backend.domain.notification.dto;
 
-import java.time.LocalDateTime;
-
 import com.adit.backend.domain.notification.enums.NotificationType;
 
 import lombok.Builder;
@@ -10,7 +8,7 @@ import lombok.Builder;
 public record NotificationResponse(String message,
 								   String category,
 								   NotificationType notificationType,
-								   LocalDateTime createdAt,
+								   String  createdAt,
 								   boolean isRead) {
 }
 

--- a/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
@@ -1,42 +1,66 @@
 package com.adit.backend.domain.notification.entity;
 
-import com.adit.backend.domain.event.entity.UserEvent;
+import org.hibernate.annotations.ColumnDefault;
+
+import com.adit.backend.domain.notification.enums.NotificationType;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.global.entity.BaseEntity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+	@NotNull
+	private String message;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private UserEvent userEvent;
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private NotificationType notificationType;
 
-    @Column(nullable = false)
-    private String content;
+	private String relatedUri;
 
-    private Boolean isRead;
+	@NotNull
+	@ColumnDefault("false")
+	private boolean isRead = false;
+
+	@NotNull
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Builder
+	public Notification(String message, NotificationType notificationType, String relatedUri) {
+		this.message = message;
+		this.notificationType = notificationType;
+		this.relatedUri = relatedUri;
+	}
+
+	//연관관계 메서드
+	public void assignUser(User user) {
+		this.user = user;
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
@@ -38,6 +38,9 @@ public class Notification extends BaseEntity {
 	private NotificationType notificationType;
 
 	@NotNull
+	private String category;
+
+	@NotNull
 	@ColumnDefault("false")
 	private boolean isRead = false;
 
@@ -47,9 +50,10 @@ public class Notification extends BaseEntity {
 	private User user;
 
 	@Builder
-	public Notification(String message, NotificationType notificationType) {
+	public Notification(String message, NotificationType notificationType, String category) {
 		this.message = message;
 		this.notificationType = notificationType;
+		this.category = category;
 	}
 
 	//연관관계 메서드

--- a/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
@@ -37,8 +37,6 @@ public class Notification extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private NotificationType notificationType;
 
-	private String relatedUri;
-
 	@NotNull
 	@ColumnDefault("false")
 	private boolean isRead = false;
@@ -49,10 +47,9 @@ public class Notification extends BaseEntity {
 	private User user;
 
 	@Builder
-	public Notification(String message, NotificationType notificationType, String relatedUri) {
+	public Notification(String message, NotificationType notificationType) {
 		this.message = message;
 		this.notificationType = notificationType;
-		this.relatedUri = relatedUri;
 	}
 
 	//연관관계 메서드

--- a/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
@@ -17,12 +17,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
@@ -48,13 +51,6 @@ public class Notification extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
-
-	@Builder
-	public Notification(String message, NotificationType notificationType, String category) {
-		this.message = message;
-		this.notificationType = notificationType;
-		this.category = category;
-	}
 
 	//연관관계 메서드
 	public void assignUser(User user) {

--- a/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/adit/backend/domain/notification/entity/Notification.java
@@ -17,15 +17,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
@@ -51,6 +48,14 @@ public class Notification extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
+
+	@Builder
+	public Notification(String message, NotificationType notificationType, String category, boolean isRead) {
+		this.message = message;
+		this.notificationType = notificationType;
+		this.category = category;
+		this.isRead = isRead;
+	}
 
 	//연관관계 메서드
 	public void assignUser(User user) {

--- a/src/main/java/com/adit/backend/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/adit/backend/domain/notification/enums/NotificationType.java
@@ -1,0 +1,19 @@
+package com.adit.backend.domain.notification.enums;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum NotificationType {
+
+	FRIEND_SAVED_MY_PLACE("친구가 같은 장소 저장 알림"),
+	UNVISITED_PLACE_REMINDER("미 방문 장소 알림"),
+	EVENT_START_SOON("이벤트 시작일 임박 알림"),
+	EVENT_DURATION_MISSING("이벤트 기간 누락 알림"),
+	FRIEND_REQUEST_RECEIVED("친구 요청 수신 알림"),
+	FRIEND_REQUEST_ACCEPTED("친구 요청 수락 알림");
+
+	private final String description;
+	}

--- a/src/main/java/com/adit/backend/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/adit/backend/domain/notification/enums/NotificationType.java
@@ -8,12 +8,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum NotificationType {
 
-	FRIEND_SAVED_MY_PLACE("친구가 같은 장소 저장 알림"),
-	UNVISITED_PLACE_REMINDER("미 방문 장소 알림"),
-	EVENT_START_SOON("이벤트 시작일 임박 알림"),
-	EVENT_DURATION_MISSING("이벤트 기간 누락 알림"),
-	FRIEND_REQUEST_RECEIVED("친구 요청 수신 알림"),
-	FRIEND_REQUEST_ACCEPTED("친구 요청 수락 알림");
+	/* ANNOUNCEMENT */
+	ANNOUNCEMENT("공지사항 알림", "ANNOUNCEMENT"),
+
+	/* PLACE */
+	PLACE_UNVISITED("미 방문 장소 알림", "PLACE"),
+
+	/* EVENT */
+	EVENT_START_SOON("이벤트 시작일 임박 알림", "EVENT"),
+	EVENT_DURATION_MISSING("이벤트 기간 누락 알림", "EVENT"),
+
+	/* FRIEND */
+	FRIEND_REQUEST_RECEIVED("친구 요청 수신 알림", "FRIEND"),
+	FRIEND_REQUEST_ACCEPTED("친구 요청 수락 알림", "FRIEND"),
+	FRIEND_SAVED_MY_PLACE("친구가 같은 장소 저장 알림", "FRIEND");
 
 	private final String description;
-	}
+	private final String category;
+}

--- a/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
@@ -1,0 +1,13 @@
+package com.adit.backend.domain.notification.event;
+
+import com.adit.backend.domain.notification.enums.NotificationType;
+
+import lombok.Builder;
+
+@Builder
+public record NotificationEvent(
+	String userKey,
+	String message,
+	NotificationType notificationType,
+	String relatedUri
+) {}

--- a/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 
 @Builder
 public record NotificationEvent(
-	String userKey,
+	String userEmail,
 	String message,
-	NotificationType notificationType,
-	String relatedUri
-) {}
+	NotificationType notificationType) {}

--- a/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
@@ -1,5 +1,7 @@
 package com.adit.backend.domain.notification.event;
 
+import java.time.LocalDateTime;
+
 import com.adit.backend.domain.notification.enums.NotificationType;
 
 import lombok.Builder;
@@ -8,4 +10,8 @@ import lombok.Builder;
 public record NotificationEvent(
 	String userEmail,
 	String message,
-	NotificationType notificationType) {}
+	String category,
+	NotificationType notificationType,
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/adit/backend/domain/notification/event/NotificationEvent.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 @Builder
 public record NotificationEvent(
 	String userEmail,
-	String message,
+	String content,
 	String category,
 	NotificationType notificationType,
 	LocalDateTime createdAt

--- a/src/main/java/com/adit/backend/domain/notification/event/NotificationEventHandler.java
+++ b/src/main/java/com/adit/backend/domain/notification/event/NotificationEventHandler.java
@@ -1,0 +1,22 @@
+package com.adit.backend.domain.notification.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.adit.backend.domain.notification.service.command.NotificationCommandService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class NotificationEventHandler {
+
+	private final NotificationCommandService notificationCommandService;
+
+	@Async
+	@EventListener // 이벤트 구독
+	public void handleEvent(NotificationEvent event) {
+		notificationCommandService.sendNotification(event); // 알림 발송 메서드
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/event/NotificationEventPublisher.java
+++ b/src/main/java/com/adit/backend/domain/notification/event/NotificationEventPublisher.java
@@ -1,0 +1,19 @@
+package com.adit.backend.domain.notification.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import com.adit.backend.domain.notification.entity.Notification;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventPublisher {
+
+	private final ApplicationEventPublisher eventPublisher;
+
+	public void publishEvent(Notification event) {
+		eventPublisher.publishEvent(event);
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Repository;
 import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.user.entity.User;
 
+import jakarta.validation.constraints.NotNull;
+
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -22,4 +24,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	@Query("SELECT n FROM Notification n WHERE n.user = :user AND n.createdAt >= :cutoffDate ORDER BY n.createdAt ASC")
 	Optional<List<Notification>> findRecentNotifications(@Param("user") User user,
 		@Param("cutoffDate") LocalDateTime cutoffDate);
+
+
+	Optional<List<Notification>> findByUserAndCategory(@NotNull User user, @NotNull String category);
 }

--- a/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Repository;
 import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.user.entity.User;
 
-import jakarta.validation.constraints.NotNull;
-
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -21,13 +19,15 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
 	Optional<List<Notification>> findAllByUserAndIdGreaterThan(User user, Long lastId);
 
-	@Query("SELECT n FROM Notification n WHERE n.user = :user AND n.createdAt >= :cutoffDate ORDER BY n.createdAt ASC")
+	@Query("SELECT n FROM Notification n WHERE n.user = :user " +
+		"AND n.createdAt >= :cutoffDate ORDER BY n.createdAt ASC")
 	Optional<List<Notification>> findRecentNotifications(@Param("user") User user,
 		@Param("cutoffDate") LocalDateTime cutoffDate);
 
-	@Query("SELECT n FROM Notification n WHERE n.user = :user"
-		+ " AND n.category = :category"
-		+ " AND n.createdAt >= :cutoffDate ORDER BY n.createdAt ASC")
-	Optional<List<Notification>> findByUserAndCategory(@NotNull User user, @NotNull String category,
-		LocalDateTime cutoffDate);
+	@Query("SELECT n FROM Notification n WHERE n.user = :user " +
+		"AND n.category = :category " +
+		"AND n.createdAt >= :cutoffDate ORDER BY n.createdAt ASC")
+	Optional<List<Notification>> findByUserAndCategory(@Param("user") User user,
+		@Param("category") String category,
+		@Param("cutoffDate") LocalDateTime cutoffDate);
 }

--- a/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
@@ -25,6 +25,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	Optional<List<Notification>> findRecentNotifications(@Param("user") User user,
 		@Param("cutoffDate") LocalDateTime cutoffDate);
 
-
-	Optional<List<Notification>> findByUserAndCategory(@NotNull User user, @NotNull String category);
+	@Query("SELECT n FROM Notification n WHERE n.user = :user"
+		+ " AND n.category = :category"
+		+ " AND n.createdAt >= :cutoffDate ORDER BY n.createdAt ASC")
+	Optional<List<Notification>> findByUserAndCategory(@NotNull User user, @NotNull String category,
+		LocalDateTime cutoffDate);
 }

--- a/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
@@ -1,8 +1,12 @@
 package com.adit.backend.domain.notification.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.adit.backend.domain.notification.entity.Notification;
@@ -12,4 +16,10 @@ import com.adit.backend.domain.user.entity.User;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
 	List<Notification> findAllByUser(User user);
+
+	Optional<List<Notification>> findAllByUserAndIdGreaterThan(User user, Long lastId);
+
+	@Query("SELECT n FROM Notification n WHERE n.user = :user AND n.createdAt >= :cutoffDate ORDER BY n.createdAt ASC")
+	Optional<List<Notification>> findRecentNotifications(@Param("user") User user,
+		@Param("cutoffDate") LocalDateTime cutoffDate);
 }

--- a/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/adit/backend/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.adit.backend.domain.notification.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.adit.backend.domain.notification.entity.Notification;
+import com.adit.backend.domain.user.entity.User;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findAllByUser(User user);
+}

--- a/src/main/java/com/adit/backend/domain/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/com/adit/backend/domain/notification/repository/SseEmitterRepository.java
@@ -3,25 +3,88 @@ package com.adit.backend.domain.notification.repository;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
 
 @Repository
 public class SseEmitterRepository {
 
 	private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+	private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
 
-	public SseEmitter save(String eventId, SseEmitter sseEmitter) {
-		emitters.put(eventId, sseEmitter);
+	/**
+	 * emitterID와 sseEmitter를 사용하여 SSE이벤트 전송 객체를 저장
+	 */
+	public SseEmitter save(String userEmail, SseEmitter sseEmitter) {
+		emitters.put(userEmail, sseEmitter);
 		return sseEmitter;
 	}
 
-	public Optional<SseEmitter> findById(String memberId) {
-		return Optional.ofNullable(emitters.get(memberId));
+	/**
+	 * 이벤트캐시 아이디와 이벤트 객체를 받아 저장.
+	 */
+	public void saveEventCache(String eventCacheId, Object event) {
+		eventCache.put(eventCacheId, event);
 	}
 
-	public void deleteById(String eventId) {
-		emitters.remove(eventId);
+	/**
+	 * 주어진 userEmail로 시작하는 모든 Emitter를 가져옴
+	 */
+	public Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String userEmail) {
+		return emitters.entrySet().stream()
+			.filter(entry -> entry.getKey().startsWith(userEmail))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	/**
+	 *
+	 */
+	public Map<String, Object> findAllEventCacheStartWithByMemberId(String userEmail) {
+		return eventCache.entrySet().stream()
+			.filter(entry -> entry.getKey().startsWith(userEmail))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	/**
+	 * 삭제
+	 */
+	public Optional<SseEmitter> findById(String userEmail) {
+		return Optional.ofNullable(emitters.get(userEmail));
+	}
+
+	/**
+	 *  해당 회원과 관련된 모든 Emitter를 지움
+	 */
+	public void deleteByUserEmail(String userEmail) {
+		emitters.remove(userEmail);
+	}
+
+	/**
+	 * 해당 회원과 관련된 모든 Emitter를 지움
+	 */
+	public void deleteAllEmitterStartWithId(String userEmail) {
+		emitters.forEach(
+			(key, emitter) -> {
+				if (key.startsWith(userEmail)) {
+					emitters.remove(key);
+				}
+			}
+		);
+	}
+
+	/**
+	 * 해당 회원과 관련된 모든 이벤트를 지움
+	 */
+	public void deleteAllEventCacheStartWithId(String userEmail) {
+		eventCache.forEach(
+			(key, emitter) -> {
+				if (key.startsWith(userEmail)) {
+					eventCache.remove(key);
+				}
+			}
+		);
 	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/com/adit/backend/domain/notification/repository/SseEmitterRepository.java
@@ -1,0 +1,27 @@
+package com.adit.backend.domain.notification.repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class SseEmitterRepository {
+
+	private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+	public SseEmitter save(String eventId, SseEmitter sseEmitter) {
+		emitters.put(eventId, sseEmitter);
+		return sseEmitter;
+	}
+
+	public Optional<SseEmitter> findById(String memberId) {
+		return Optional.ofNullable(emitters.get(memberId));
+	}
+
+	public void deleteById(String eventId) {
+		emitters.remove(eventId);
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/NotificationDemoDayService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/NotificationDemoDayService.java
@@ -1,0 +1,71 @@
+package com.adit.backend.domain.notification.service;
+
+import org.springframework.stereotype.Service;
+
+import com.adit.backend.domain.event.entity.UserEvent;
+import com.adit.backend.domain.event.exception.EventException;
+import com.adit.backend.domain.event.repository.UserEventRepository;
+import com.adit.backend.domain.notification.converter.NotificationEventConverter;
+import com.adit.backend.domain.notification.event.NotificationEvent;
+import com.adit.backend.domain.notification.service.command.NotificationCommandService;
+import com.adit.backend.domain.place.entity.UserPlace;
+import com.adit.backend.domain.place.exception.PlaceException;
+import com.adit.backend.domain.place.repository.UserPlaceRepository;
+import com.adit.backend.domain.place.service.query.UserPlaceQueryService;
+import com.adit.backend.global.error.GlobalErrorCode;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 데모데이를 위한 서비스입니다 😅
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationDemoDayService {
+	private final NotificationEventConverter eventConverter;
+	private final UserPlaceQueryService userPlaceQueryService;
+	private final UserPlaceRepository userPlaceRepository;
+	private final NotificationCommandService notificationCommandService;
+	private final UserEventRepository userEventRepository;
+
+	/**
+	 *  원영이형한테 기간입력하라고 알림보내기
+	 *  1. 원영이형의 유저 ID == 1
+	 *  2. 기간 미입력된 이벤트를 ID 1 로 정의
+	 */
+	public void sendDurationNotification() {
+		UserEvent userEvent = userEventRepository.findById(1L)
+			.orElseThrow(() -> new EventException(GlobalErrorCode.EVENT_NOT_FOUND));
+		NotificationEvent event = eventConverter.toMissingEvent(userEvent);
+		notificationCommandService.sendNotification(event);
+	}
+
+	/**
+	 *  원영이형한테 방문하라고 알림보내기
+	 *  1. 원영이형의 유저 ID == 1
+	 *  2. 알림을 보내고싶은 임의의 장소를 ID 1 로 정의
+	 */
+	public void sendUnvisitedNotification() {
+		UserPlace userPlace = userPlaceRepository.findById(1L)
+			.orElseThrow(() -> new PlaceException(GlobalErrorCode.USER_PLACE_NOT_FOUND));
+		NotificationEvent event = eventConverter.toUnvisitedEvent(userPlace);
+		notificationCommandService.sendNotification(event);
+	}
+
+
+	/**
+	 *  원영이형한테 방문하라고 알림보내기
+	 *  1. 원영이형의 유저 ID == 1
+	 *  2. 알림을 보내고싶은 임의의 장소를 시작 일이 데모데이 기준 3일 남도록 데이터 저장
+	 */
+	public void sendStartNotification() {
+		UserEvent userEvent = userEventRepository.findById(1L)
+			.orElseThrow(() -> new EventException(GlobalErrorCode.EVENT_NOT_FOUND));
+		NotificationEvent event = eventConverter.toStartEvent(userEvent, 3);
+		notificationCommandService.sendNotification(event);
+	}
+
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/NotificationGenerationService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/NotificationGenerationService.java
@@ -1,0 +1,46 @@
+package com.adit.backend.domain.notification.service;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.adit.backend.domain.notification.converter.NotificationEventConverter;
+import com.adit.backend.domain.notification.event.NotificationEvent;
+import com.adit.backend.domain.notification.service.command.NotificationCommandService;
+import com.adit.backend.domain.place.entity.CommonPlace;
+import com.adit.backend.domain.place.entity.UserPlace;
+import com.adit.backend.domain.place.service.query.UserPlaceQueryService;
+import com.adit.backend.domain.user.entity.Friendship;
+import com.adit.backend.domain.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+
+public class NotificationGenerationService {
+
+	private final NotificationEventConverter notificationEventConverter;
+	private final NotificationCommandService notificationCommandService;
+	private final UserPlaceQueryService userPlaceQueryService;
+
+	@Async
+	public void createNotificationOfAFriendRequest(Friendship friendship) {
+		NotificationEvent event = notificationEventConverter.toRequestEvent(friendship);
+		notificationCommandService.sendNotification(event);
+	}
+
+	@Async
+	public void createNotificationOfAFriendAccept(Friendship friendship) {
+		NotificationEvent event = notificationEventConverter.toAcceptEvent(friendship);
+		notificationCommandService.sendNotification(event);
+	}
+
+	@Async
+	public void createNotificationOfASavedPlace(User user, CommonPlace commonPlace, UserPlace userPlace) {
+		userPlaceQueryService.findRelatedUserPlace(user, commonPlace)
+			.stream()
+			.map(friendUserPlace -> notificationEventConverter.toSavedEvent(userPlace, friendUserPlace.getUser()))
+			.forEach(notificationCommandService::sendNotification);
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/RedisMessageService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/RedisMessageService.java
@@ -1,0 +1,42 @@
+package com.adit.backend.domain.notification.service;
+
+import static com.adit.backend.domain.notification.constants.Channel.*;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+
+import com.adit.backend.domain.notification.dto.NotificationResponse;
+import com.adit.backend.domain.notification.service.handler.RedisSubscriber;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RedisMessageService {
+
+	private final RedisMessageListenerContainer container;
+	private final RedisSubscriber subscriber;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	// 채널 구독
+	public void subscribe(String channel) {
+		container.addMessageListener(subscriber, ChannelTopic.of(getChannelName(channel)));
+	}
+
+	// 이벤트 발행
+	public void publish(String channel, NotificationResponse response) {
+		redisTemplate.convertAndSend(getChannelName(channel), response);
+	}
+
+	// 구독 삭제
+	public void removeSubscribe(String channel) {
+		container.removeMessageListener(subscriber, ChannelTopic.of(getChannelName(channel)));
+	}
+
+	private String getChannelName(String id) {
+		return CHANNEL_PREFIX + id;
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/SseEmitterService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/SseEmitterService.java
@@ -1,0 +1,51 @@
+package com.adit.backend.domain.notification.service;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.adit.backend.domain.notification.dto.NotificationResponse;
+import com.adit.backend.domain.notification.repository.SseEmitterRepository;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class SseEmitterService {
+
+	private final SseEmitterRepository sseEmitterRepository;
+
+	@Value("${sse.timeout}")
+	private Long timeout;
+
+	public SseEmitter createEmitter(String emitterKey) {
+		return sseEmitterRepository.save(emitterKey, new SseEmitter(timeout));
+	}
+
+	public void deleteEmitter(String emitterKey) {
+		sseEmitterRepository.deleteById(emitterKey);
+	}
+
+	public void sendNotificationToClient(String emitterKey, NotificationResponse response) {
+		sseEmitterRepository.findById(emitterKey)
+			.ifPresent(emitter -> send(response, emitterKey, emitter));
+	}
+
+	public void send(Object data, String emitterKey, SseEmitter sseEmitter) {
+		try {
+			log.info("send to client {}:[{}]", emitterKey, data);
+			sseEmitter.send(SseEmitter.event()
+				.id(emitterKey)
+				.data(data, MediaType.APPLICATION_JSON));
+		} catch (IOException | IllegalStateException e) {
+			log.error("[Notification] IOException 또는 IllegalStateException이 발생했습니다.", e);
+			sseEmitterRepository.deleteById(emitterKey);
+		}
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
@@ -1,8 +1,5 @@
 package com.adit.backend.domain.notification.service.command;
 
-import java.net.URI;
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -12,7 +9,6 @@ import com.adit.backend.domain.notification.converter.NotificationConverter;
 import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.notification.event.NotificationEvent;
 import com.adit.backend.domain.notification.repository.NotificationRepository;
-import com.adit.backend.domain.notification.repository.SseEmitterRepository;
 import com.adit.backend.domain.notification.service.RedisMessageService;
 import com.adit.backend.domain.notification.service.SseEmitterService;
 import com.adit.backend.domain.notification.service.query.NotificationQueryService;
@@ -28,45 +24,59 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationCommandService {
 	private final NotificationRepository notificationRepository;
-	private final SseEmitterRepository sseEmitterRepository;
+
 	private final UserQueryService userQueryService;
-	private final NotificationConverter converter;
 	private final SseEmitterService sseEmitterService;
 	private final RedisMessageService redisMessageService;
 	private final NotificationQueryService notificationQueryService;
 
-	@Value("${sse.timeout}")
-	private Long timeout;
+	private final NotificationConverter converter;
 
-	public SseEmitter subscribe(String userKey) {
-		SseEmitter sseEmitter = sseEmitterService.createEmitter(userKey);
-		sseEmitterService.send(MsgFormat.SUBSCRIBE, userKey, sseEmitter); // send dummy
+	/**
+	 * 사용자가 SSE 구독을 시작합니다.
+	 *
+	 * @param userEmail   사용자 이메일
+	 * @param lastEventId 마지막 이벤트 ID
+	 * @return 생성된 SSE Emitter 객체
+	 */
+	public SseEmitter subscribe(String userEmail, String lastEventId) {
+		SseEmitter sseEmitter = sseEmitterService.createEmitter(userEmail);
+		sseEmitterService.send(MsgFormat.SUBSCRIBE, userEmail, sseEmitter);
+		redisMessageService.subscribe(userEmail);
 
-		redisMessageService.subscribe(userKey);
-
-		sseEmitter.onTimeout(sseEmitter::complete);
-		sseEmitter.onError((e) -> sseEmitter.complete());
 		sseEmitter.onCompletion(() -> {
-			sseEmitterService.deleteEmitter(userKey);
-			redisMessageService.removeSubscribe(userKey);
+			log.debug("[SSE] onCompletion callback : {}", userEmail);
+			sseEmitterService.deleteEmitter(userEmail);
+			redisMessageService.removeSubscribe(userEmail);
 		});
+		sseEmitter.onTimeout(() -> {
+			log.warn("[SSE] Timeout callback: {}", userEmail);
+			sseEmitter.complete();
+		});
+		sseEmitter.onError((e) -> {
+			log.error("[SSE] 에러 발생", e);
+			sseEmitter.complete();
+		});
+
+		notificationQueryService.sendMissedNotifications(lastEventId, userEmail, sseEmitter);
+
 		return sseEmitter;
 	}
 
+	/**
+	 * 주어진 이벤트를 기반으로 알림을 생성하고 저장합니다.
+	 * 알림을 생성한 후, Redis를 통해 해당 사용자에게 알림을 발행합니다.
+	 *
+	 * @param event 알림 이벤트 객체
+	 */
 	@Transactional
 	public void sendNotification(NotificationEvent event) {
-		User user = userQueryService.findUserByEmail(event.userKey());
-		Notification notification = converter.toEntity(event.message(), event.notificationType(), event.relatedUri());
+		User user = userQueryService.findUserByEmail(event.userEmail());
+
+		Notification notification = converter.toEntity(event.message(), event.notificationType());
 		notification.assignUser(user);
 		notificationRepository.save(notification);
-		redisMessageService.publish(event.userKey(), converter.toResponse(notification));
-	}
 
-	@Transactional
-	public URI getRedirectUri(Long notificationId) {
-		Notification notification = notificationQueryService.findNotificationById(notificationId);
-		notification.markAsRead();
-		return URI.create(notification.getRelatedUri());
+		redisMessageService.publish(event.userEmail(), converter.toResponse(notification));
 	}
-
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
@@ -1,0 +1,72 @@
+package com.adit.backend.domain.notification.service.command;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.adit.backend.domain.notification.constants.MsgFormat;
+import com.adit.backend.domain.notification.converter.NotificationConverter;
+import com.adit.backend.domain.notification.entity.Notification;
+import com.adit.backend.domain.notification.event.NotificationEvent;
+import com.adit.backend.domain.notification.repository.NotificationRepository;
+import com.adit.backend.domain.notification.repository.SseEmitterRepository;
+import com.adit.backend.domain.notification.service.RedisMessageService;
+import com.adit.backend.domain.notification.service.SseEmitterService;
+import com.adit.backend.domain.notification.service.query.NotificationQueryService;
+import com.adit.backend.domain.user.entity.User;
+import com.adit.backend.domain.user.service.query.UserQueryService;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationCommandService {
+	private final NotificationRepository notificationRepository;
+	private final SseEmitterRepository sseEmitterRepository;
+	private final UserQueryService userQueryService;
+	private final NotificationConverter converter;
+	private final SseEmitterService sseEmitterService;
+	private final RedisMessageService redisMessageService;
+	private final NotificationQueryService notificationQueryService;
+
+	@Value("${sse.timeout}")
+	private Long timeout;
+
+	public SseEmitter subscribe(String userKey) {
+		SseEmitter sseEmitter = sseEmitterService.createEmitter(userKey);
+		sseEmitterService.send(MsgFormat.SUBSCRIBE, userKey, sseEmitter); // send dummy
+
+		redisMessageService.subscribe(userKey);
+
+		sseEmitter.onTimeout(sseEmitter::complete);
+		sseEmitter.onError((e) -> sseEmitter.complete());
+		sseEmitter.onCompletion(() -> {
+			sseEmitterService.deleteEmitter(userKey);
+			redisMessageService.removeSubscribe(userKey);
+		});
+		return sseEmitter;
+	}
+
+	@Transactional
+	public void sendNotification(NotificationEvent event) {
+		User user = userQueryService.findUserByEmail(event.userKey());
+		Notification notification = converter.toEntity(event.message(), event.notificationType(), event.relatedUri());
+		notification.assignUser(user);
+		notificationRepository.save(notification);
+		redisMessageService.publish(event.userKey(), converter.toResponse(notification));
+	}
+
+	@Transactional
+	public URI getRedirectUri(Long notificationId) {
+		Notification notification = notificationQueryService.findNotificationById(notificationId);
+		notification.markAsRead();
+		return URI.create(notification.getRelatedUri());
+	}
+
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
@@ -1,5 +1,6 @@
 package com.adit.backend.domain.notification.service.command;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -13,6 +14,9 @@ import com.adit.backend.domain.notification.repository.NotificationRepository;
 import com.adit.backend.domain.notification.service.RedisMessageService;
 import com.adit.backend.domain.notification.service.SseEmitterService;
 import com.adit.backend.domain.notification.service.query.NotificationQueryService;
+import com.adit.backend.domain.place.entity.CommonPlace;
+import com.adit.backend.domain.place.entity.UserPlace;
+import com.adit.backend.domain.place.service.query.UserPlaceQueryService;
 import com.adit.backend.domain.user.entity.Friendship;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.service.query.UserQueryService;
@@ -31,6 +35,7 @@ public class NotificationCommandService {
 	private final SseEmitterService sseEmitterService;
 	private final RedisMessageService redisMessageService;
 	private final NotificationQueryService notificationQueryService;
+	private final UserPlaceQueryService userPlaceQueryService;
 
 	private final NotificationConverter notificationConverter;
 	private final NotificationEventConverter notificationEventConverter;
@@ -88,8 +93,12 @@ public class NotificationCommandService {
 		sendNotification(event);
 	}
 
-	public void createNotificationOfAFriendAccept(Friendship friendRequest) {
-
+	@Async
+	public void createNotificationOfASavedPlace(User user, CommonPlace commonPlace, UserPlace userPlace) {
+		userPlaceQueryService.findRelatedUserPlace(user, commonPlace)
+			.stream()
+			.map(friendUserPlace -> notificationEventConverter.toSavedEvent(userPlace, friendUserPlace.getUser()))
+			.forEach(this::sendNotification);
 	}
 
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
@@ -76,7 +76,7 @@ public class NotificationCommandService {
 	public void sendNotification(NotificationEvent event) {
 		User user = userQueryService.findUserByEmail(event.userEmail());
 
-		Notification notification = notificationConverter.toEntity(event.message(), event.notificationType());
+		Notification notification = notificationConverter.toEntity(event.content(), event.notificationType());
 		notification.assignUser(user);
 		notificationRepository.save(notification);
 

--- a/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
@@ -6,12 +6,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.adit.backend.domain.notification.constants.MsgFormat;
 import com.adit.backend.domain.notification.converter.NotificationConverter;
+import com.adit.backend.domain.notification.converter.NotificationEventConverter;
 import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.notification.event.NotificationEvent;
 import com.adit.backend.domain.notification.repository.NotificationRepository;
 import com.adit.backend.domain.notification.service.RedisMessageService;
 import com.adit.backend.domain.notification.service.SseEmitterService;
 import com.adit.backend.domain.notification.service.query.NotificationQueryService;
+import com.adit.backend.domain.user.entity.Friendship;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.service.query.UserQueryService;
 
@@ -30,7 +32,8 @@ public class NotificationCommandService {
 	private final RedisMessageService redisMessageService;
 	private final NotificationQueryService notificationQueryService;
 
-	private final NotificationConverter converter;
+	private final NotificationConverter notificationConverter;
+	private final NotificationEventConverter notificationEventConverter;
 
 	/**
 	 * 사용자가 SSE 구독을 시작합니다.
@@ -73,10 +76,20 @@ public class NotificationCommandService {
 	public void sendNotification(NotificationEvent event) {
 		User user = userQueryService.findUserByEmail(event.userEmail());
 
-		Notification notification = converter.toEntity(event.message(), event.notificationType());
+		Notification notification = notificationConverter.toEntity(event.message(), event.notificationType());
 		notification.assignUser(user);
 		notificationRepository.save(notification);
 
-		redisMessageService.publish(event.userEmail(), converter.toResponse(notification));
+		redisMessageService.publish(event.userEmail(), notificationConverter.toResponse(notification));
 	}
+
+	public void createNotificationOfAFriendRequest(Friendship savedForwardRequest) {
+		NotificationEvent event = notificationEventConverter.toRequestEvent(savedForwardRequest);
+		sendNotification(event);
+	}
+
+	public void createNotificationOfAFriendAccept(Friendship friendRequest) {
+
+	}
+
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
@@ -83,4 +83,15 @@ public class NotificationCommandService {
 
 		redisMessageService.publish(event.userEmail(), notificationConverter.toResponse(notification));
 	}
+
+	/**
+	 * 주어진 사용자 이메일에 해당하는 SSE 구독을 종료합니다.
+	 *
+	 * @param userEmail 종료할 사용자 이메일
+	 */
+	public void unsubscribe(String userEmail) {
+		sseEmitterService.deleteEmitter(userEmail);
+		redisMessageService.removeSubscribe(userEmail);
+	}
+
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/command/NotificationCommandService.java
@@ -1,6 +1,5 @@
 package com.adit.backend.domain.notification.service.command;
 
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -14,10 +13,7 @@ import com.adit.backend.domain.notification.repository.NotificationRepository;
 import com.adit.backend.domain.notification.service.RedisMessageService;
 import com.adit.backend.domain.notification.service.SseEmitterService;
 import com.adit.backend.domain.notification.service.query.NotificationQueryService;
-import com.adit.backend.domain.place.entity.CommonPlace;
-import com.adit.backend.domain.place.entity.UserPlace;
 import com.adit.backend.domain.place.service.query.UserPlaceQueryService;
-import com.adit.backend.domain.user.entity.Friendship;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.service.query.UserQueryService;
 
@@ -87,18 +83,4 @@ public class NotificationCommandService {
 
 		redisMessageService.publish(event.userEmail(), notificationConverter.toResponse(notification));
 	}
-
-	public void createNotificationOfAFriendRequest(Friendship savedForwardRequest) {
-		NotificationEvent event = notificationEventConverter.toRequestEvent(savedForwardRequest);
-		sendNotification(event);
-	}
-
-	@Async
-	public void createNotificationOfASavedPlace(User user, CommonPlace commonPlace, UserPlace userPlace) {
-		userPlaceQueryService.findRelatedUserPlace(user, commonPlace)
-			.stream()
-			.map(friendUserPlace -> notificationEventConverter.toSavedEvent(userPlace, friendUserPlace.getUser()))
-			.forEach(this::sendNotification);
-	}
-
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/handler/RedisSubscriber.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/handler/RedisSubscriber.java
@@ -1,0 +1,42 @@
+package com.adit.backend.domain.notification.service.handler;
+
+import static com.adit.backend.domain.notification.constants.Channel.*;
+
+import java.io.IOException;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import com.adit.backend.domain.notification.dto.NotificationResponse;
+import com.adit.backend.domain.notification.service.SseEmitterService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RedisSubscriber implements MessageListener {
+
+	private final ObjectMapper objectMapper;
+	private final SseEmitterService sseEmitterService;
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		try {
+			String channel = new String(message.getChannel())
+				.substring(CHANNEL_PREFIX.length());
+
+			NotificationResponse response = objectMapper.readValue(message.getBody(),
+				NotificationResponse.class);
+
+			// 클라이언트에게 event 데이터 전송
+			sseEmitterService.sendNotificationToClient(channel, response);
+		} catch (IOException e) {
+			log.error("IOException is occurred. ", e);
+		}
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
@@ -84,7 +84,8 @@ public class NotificationQueryService {
 	}
 
 	public List<Notification> getNotificationsByCategory(User user, String category) {
-		return notificationRepository.findByUserAndCategory(user, category)
+		LocalDateTime cutoffDate = LocalDateTime.now().minusDays(7);
+		return notificationRepository.findByUserAndCategory(user, category, cutoffDate)
 			.orElse(Collections.emptyList());
 	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
@@ -83,9 +83,11 @@ public class NotificationQueryService {
 			});
 	}
 
-	public List<Notification> getNotificationsByCategory(User user, String category) {
+	public List<NotificationResponse> getNotificationsByCategory(User user, String category) {
 		LocalDateTime cutoffDate = LocalDateTime.now().minusDays(7);
 		return notificationRepository.findByUserAndCategory(user, category, cutoffDate)
-			.orElse(Collections.emptyList());
+			.orElse(Collections.emptyList())
+			.stream().map(converter::toResponse)
+			.toList();
 	}
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
@@ -2,13 +2,17 @@ package com.adit.backend.domain.notification.service.query;
 
 import static com.adit.backend.global.error.GlobalErrorCode.*;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.adit.backend.domain.notification.converter.NotificationConverter;
-import com.adit.backend.domain.notification.dto.NotificationResponse;
 import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.notification.exception.NotificationException;
 import com.adit.backend.domain.notification.repository.NotificationRepository;
@@ -34,10 +38,47 @@ public class NotificationQueryService {
 			.orElseThrow(() -> new NotificationException(NOTIFICATION_NOT_FOUND));
 	}
 
-	public List<NotificationResponse> getAllNotifications(String userKey) {
-		User user = userQueryService.findUserByEmail(userKey);
-		return notificationRepository.findAllByUser(user)
-			.stream().map(converter::toResponse)
-			.toList();
+	public List<Notification> getRecentNotifications(String userEmail) {
+		User user = userQueryService.findUserByEmail(userEmail);
+		LocalDateTime cutoffDate = LocalDateTime.now().minusDays(7);
+		return notificationRepository.findRecentNotifications(user, cutoffDate)
+			.orElse(Collections.emptyList())
+			.stream().toList();
 	}
+
+	public List<Notification> getMissedNotifications(User user, Long lastId) {
+		return notificationRepository.findAllByUserAndIdGreaterThan(user, lastId)
+			.orElse(Collections.emptyList());
+	}
+
+	/**
+	 * 주어진 사용자 이메일과 마지막 이벤트 ID를 기반으로 누락된 알림을 찾아 SSE로 전송합니다.
+	 *
+	 * @param lastEventId 마지막 이벤트 ID (클라이언트가 재접속 시 전달)
+	 * @param userEmail   사용자 이메일
+	 * @param emitter     SSE Emitter
+	 */
+	public void sendMissedNotifications(String lastEventId, String userEmail, SseEmitter emitter) {
+		if (lastEventId.isEmpty()) {
+			return;
+		}
+
+		Long lastId = Long.parseLong(lastEventId);
+		User user = userQueryService.findUserByEmail(userEmail);
+		List<Notification> missedNotifications = getMissedNotifications(user, lastId);
+
+		missedNotifications.stream()
+			.sorted(Comparator.comparingLong(Notification::getId))
+			.forEach(notification -> {
+				try {
+					emitter.send(SseEmitter.event()
+						.id(String.valueOf(notification.getId()))
+						.data(converter.toResponse(notification)));
+				} catch (IOException e) {
+					log.error("[SSE] 누락된 알림 수신 중 오류 발생", e);
+					emitter.completeWithError(e);
+				}
+			});
+	}
+
 }

--- a/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
@@ -1,0 +1,43 @@
+package com.adit.backend.domain.notification.service.query;
+
+import static com.adit.backend.global.error.GlobalErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.adit.backend.domain.notification.converter.NotificationConverter;
+import com.adit.backend.domain.notification.dto.NotificationResponse;
+import com.adit.backend.domain.notification.entity.Notification;
+import com.adit.backend.domain.notification.exception.NotificationException;
+import com.adit.backend.domain.notification.repository.NotificationRepository;
+import com.adit.backend.domain.user.entity.User;
+import com.adit.backend.domain.user.service.query.UserQueryService;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationQueryService {
+
+	private final NotificationRepository notificationRepository;
+	private final UserQueryService userQueryService;
+	private final NotificationConverter converter;
+
+	public Notification findNotificationById(Long id) {
+		return notificationRepository.findById(id)
+			.orElseThrow(() -> new NotificationException(NOTIFICATION_NOT_FOUND));
+	}
+
+	public List<NotificationResponse> getAllNotifications(String userKey) {
+		User user = userQueryService.findUserByEmail(userKey);
+		return notificationRepository.findAllByUser(user)
+			.stream().map(converter::toResponse)
+			.toList();
+	}
+}

--- a/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
+++ b/src/main/java/com/adit/backend/domain/notification/service/query/NotificationQueryService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.adit.backend.domain.notification.converter.NotificationConverter;
+import com.adit.backend.domain.notification.dto.NotificationResponse;
 import com.adit.backend.domain.notification.entity.Notification;
 import com.adit.backend.domain.notification.exception.NotificationException;
 import com.adit.backend.domain.notification.repository.NotificationRepository;
@@ -38,12 +39,13 @@ public class NotificationQueryService {
 			.orElseThrow(() -> new NotificationException(NOTIFICATION_NOT_FOUND));
 	}
 
-	public List<Notification> getRecentNotifications(String userEmail) {
+	public List<NotificationResponse> getRecentNotifications(String userEmail) {
 		User user = userQueryService.findUserByEmail(userEmail);
 		LocalDateTime cutoffDate = LocalDateTime.now().minusDays(7);
 		return notificationRepository.findRecentNotifications(user, cutoffDate)
 			.orElse(Collections.emptyList())
-			.stream().toList();
+			.stream().map(converter::toResponse)
+			.toList();
 	}
 
 	public List<Notification> getMissedNotifications(User user, Long lastId) {
@@ -81,4 +83,8 @@ public class NotificationQueryService {
 			});
 	}
 
+	public List<Notification> getNotificationsByCategory(User user, String category) {
+		return notificationRepository.findByUserAndCategory(user, category)
+			.orElse(Collections.emptyList());
+	}
 }

--- a/src/main/java/com/adit/backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/adit/backend/domain/place/controller/PlaceController.java
@@ -15,11 +15,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.adit.backend.domain.image.dto.response.ImageResponseDto;
 import com.adit.backend.domain.place.dto.request.PlaceRequestDto;
 import com.adit.backend.domain.place.dto.response.FriendPlaceResponseDto;
 import com.adit.backend.domain.place.dto.response.PlaceResponseDto;

--- a/src/main/java/com/adit/backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/adit/backend/domain/place/controller/PlaceController.java
@@ -1,6 +1,7 @@
 package com.adit.backend.domain.place.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,11 +18,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.adit.backend.domain.place.dto.request.PlaceRequestDto;
+import com.adit.backend.domain.place.dto.response.FriendPlaceResponseDto;
 import com.adit.backend.domain.place.dto.response.PlaceResponseDto;
 import com.adit.backend.domain.place.service.command.CommonPlaceCommandService;
 import com.adit.backend.domain.place.service.command.UserPlaceCommandService;
 import com.adit.backend.domain.place.service.query.CommonPlaceQueryService;
 import com.adit.backend.domain.place.service.query.UserPlaceQueryService;
+import com.adit.backend.domain.user.dto.response.UserResponse;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.global.common.ApiResponse;
 
@@ -145,12 +148,15 @@ public class PlaceController {
 	}
 
 	//친구 기반 장소 찾기 API
-	@Operation(summary = "친구 장소 조회", description = "userId에 해당하는 사용자의 친구가 저장한 장소 조회")
+	@Operation(summary = "친구 장소 조회", description = "userId에 해당하는 사용자의 친구들이 저장한 장소를, 저장한 친구 수가 많은 순서대로 조회")
 	@GetMapping("/friend")
-	public ResponseEntity<ApiResponse<List<PlaceResponseDto>>> getPlaceByFriend(
+	public ResponseEntity<ApiResponse<List<FriendPlaceResponseDto>>> getPlaceByFriend(
 		@AuthenticationPrincipal(expression = "user") User user) {
-		List<PlaceResponseDto> placeByFriend = userPlaceQueryService.getPlaceByFriend(user.getId());
-		return ResponseEntity.ok(ApiResponse.success(placeByFriend));
+		Map<PlaceResponseDto, List<UserResponse.InfoDto>> placeByFriend = userPlaceQueryService.getPlaceByFriend(user.getId());
+		List<FriendPlaceResponseDto> responseList = placeByFriend.entrySet().stream()
+			.map(entry -> new FriendPlaceResponseDto(entry.getKey(), entry.getValue()))
+			.toList();
+		return ResponseEntity.ok(ApiResponse.success(responseList));
 	}
 
 	//장소 메모 수정 API

--- a/src/main/java/com/adit/backend/domain/place/dto/response/FriendPlaceResponseDto.java
+++ b/src/main/java/com/adit/backend/domain/place/dto/response/FriendPlaceResponseDto.java
@@ -1,0 +1,9 @@
+package com.adit.backend.domain.place.dto.response;
+
+import java.util.List;
+
+import com.adit.backend.domain.user.dto.response.UserResponse;
+
+public record FriendPlaceResponseDto(PlaceResponseDto place, List<UserResponse.InfoDto> userList) {
+
+}

--- a/src/main/java/com/adit/backend/domain/place/repository/PlaceStatisticsRepository.java
+++ b/src/main/java/com/adit/backend/domain/place/repository/PlaceStatisticsRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.PlaceStatistics;
 
 @Repository

--- a/src/main/java/com/adit/backend/domain/place/repository/UserPlaceRepository.java
+++ b/src/main/java/com/adit/backend/domain/place/repository/UserPlaceRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.adit.backend.domain.place.dto.request.PlaceRequestDto;
 import com.adit.backend.domain.place.entity.UserPlace;
-import com.adit.backend.domain.user.entity.User;
 
 @Repository
 public interface UserPlaceRepository extends JpaRepository<UserPlace, Long> {
@@ -22,9 +20,15 @@ public interface UserPlaceRepository extends JpaRepository<UserPlace, Long> {
 
 	@Query("SELECT up FROM UserPlace up where up.commonPlace.addressName LIKE %:partialAddress% AND up.user.id = :userId")
 	List<UserPlace> findByAddress(@Param("partialAddress") String partialAddress, @Param("userId") Long userId);
+
 	@Query("SELECT up FROM UserPlace up where up.user.id = :id AND up.commonPlace = (SELECT cp FROM CommonPlace cp where cp.url = :url)")
 	UserPlace findDuplicatePlace(@Param("id") Long userId, @Param("url") String requestUrl);
 
 	@Query("SELECT up.user.id FROM UserPlace up where up.commonPlace.id = :id")
 	List<Long> findByCommonPlaceId(@Param("id") Long id);
+
+	@Query("SELECT up FROM UserPlace up "
+		+ "WHERE up.user.id IN (SELECT f.toUser.id FROM Friendship f WHERE f.fromUser.id = :userId AND f.status = true) "
+		+ "AND up.commonPlace.id = :commonPlaceId")
+	Optional<List<UserPlace>> findAllFriendsUserPlace(@Param("userId") Long userId, @Param("commonPlaceId") Long commonPlaceId);
 }

--- a/src/main/java/com/adit/backend/domain/place/service/command/PlaceStatisticsCommandService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/command/PlaceStatisticsCommandService.java
@@ -1,7 +1,6 @@
 package com.adit.backend.domain.place.service.command;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.PlaceStatistics;
@@ -11,7 +10,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaceStatisticsCommandService {
 
 	private final PlaceStatisticsRepository placeStatisticsRepository;

--- a/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
@@ -12,8 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.adit.backend.domain.image.entity.Image;
 import com.adit.backend.domain.image.enums.Directory;
 import com.adit.backend.domain.image.service.command.ImageCommandService;
-import com.adit.backend.domain.notification.converter.NotificationEventConverter;
-import com.adit.backend.domain.notification.service.command.NotificationCommandService;
+import com.adit.backend.domain.notification.service.NotificationGenerationService;
 import com.adit.backend.domain.place.converter.CommonPlaceConverter;
 import com.adit.backend.domain.place.converter.UserPlaceConverter;
 import com.adit.backend.domain.place.dto.request.PlaceRequestDto;
@@ -22,7 +21,6 @@ import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.UserPlace;
 import com.adit.backend.domain.place.exception.PlaceException;
 import com.adit.backend.domain.place.repository.UserPlaceRepository;
-import com.adit.backend.domain.place.service.query.UserPlaceQueryService;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.service.query.UserQueryService;
 import com.adit.backend.global.error.exception.BusinessException;
@@ -40,12 +38,10 @@ public class UserPlaceCommandService {
 	private final CommonPlaceCommandService commonPlaceCommandService;
 	private final ImageCommandService imageCommandService;
 	private final PlaceStatisticsCommandService placeStatisticsCommandService;
-	private final UserPlaceQueryService userPlaceQueryService;
+	private final NotificationGenerationService notificationGenerationService;
 
-	private final NotificationEventConverter notificationEventConverter;
 	private final CommonPlaceConverter commonPlaceConverter;
 	private final UserPlaceConverter userPlaceConverter;
-	private final NotificationCommandService notificationCommandService;
 
 	// 장소 저장시, EventStatistics.bookmarkCount 증가
 	public PlaceResponseDto createUserPlace(Long userId, PlaceRequestDto request) {
@@ -95,7 +91,7 @@ public class UserPlaceCommandService {
 		user.addUserPlace(userPlace);
 		commonPlace.addUserPlace(userPlace);
 		userPlaceRepository.save(userPlace);
-		notificationCommandService.createNotificationOfASavedPlace(user, commonPlace, userPlace);
+		notificationGenerationService.createNotificationOfASavedPlace(user, commonPlace, userPlace);
 	}
 
 	public boolean duplicatePlace(Long userId, PlaceRequestDto request) {

--- a/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
@@ -9,15 +9,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.adit.backend.domain.event.entity.EventStatistics;
-import com.adit.backend.domain.event.repository.EventStatisticsRepository;
-import com.adit.backend.domain.image.converter.ImageConverter;
-import com.adit.backend.domain.image.dto.response.ImageResponseDto;
 import com.adit.backend.domain.image.entity.Image;
 import com.adit.backend.domain.image.enums.Directory;
-import com.adit.backend.domain.image.exception.ImageException;
-import com.adit.backend.domain.image.repository.ImageRepository;
 import com.adit.backend.domain.image.service.command.ImageCommandService;
+import com.adit.backend.domain.notification.converter.NotificationEventConverter;
+import com.adit.backend.domain.notification.service.command.NotificationCommandService;
 import com.adit.backend.domain.place.converter.CommonPlaceConverter;
 import com.adit.backend.domain.place.converter.UserPlaceConverter;
 import com.adit.backend.domain.place.dto.request.PlaceRequestDto;
@@ -26,6 +22,7 @@ import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.UserPlace;
 import com.adit.backend.domain.place.exception.PlaceException;
 import com.adit.backend.domain.place.repository.UserPlaceRepository;
+import com.adit.backend.domain.place.service.query.UserPlaceQueryService;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.service.query.UserQueryService;
 import com.adit.backend.global.error.exception.BusinessException;
@@ -38,33 +35,28 @@ import lombok.RequiredArgsConstructor;
 public class UserPlaceCommandService {
 
 	private final UserPlaceRepository userPlaceRepository;
-	private final EventStatisticsRepository eventStatisticsRepository;
-	private final CommonPlaceConverter commonPlaceConverter;
-	private final UserPlaceConverter userPlaceConverter;
+
 	private final UserQueryService userQueryService;
 	private final CommonPlaceCommandService commonPlaceCommandService;
 	private final ImageCommandService imageCommandService;
 	private final PlaceStatisticsCommandService placeStatisticsCommandService;
-	private final ImageRepository imageRepository;
-	private final ImageConverter imageConverter;
+	private final UserPlaceQueryService userPlaceQueryService;
+
+	private final NotificationEventConverter notificationEventConverter;
+	private final CommonPlaceConverter commonPlaceConverter;
+	private final UserPlaceConverter userPlaceConverter;
+	private final NotificationCommandService notificationCommandService;
 
 	// 장소 저장시, EventStatistics.bookmarkCount 증가
 	public PlaceResponseDto createUserPlace(Long userId, PlaceRequestDto request) {
 		//장소 중복 검사
-		if(!duplicatePlace(userId, request)) {
+		if (!duplicatePlace(userId, request)) {
 			throw new PlaceException(USER_PLACE_DUPLICATE);
 		}
 		User user = userQueryService.findUserById(userId);
 		CommonPlace commonPlace = commonPlaceCommandService.saveOrFindCommonPlace(request);
 		UserPlace userPlace = userPlaceConverter.toEntity(request);
 		saveUserPlaceRelation(user, commonPlace, userPlace);
-
-		/**
-		 * EventStatistics의 bookmarkCount 증가
- 		 */
-		eventStatisticsRepository.findByCommonEventId(commonPlace.getId())
-			.ifPresent(EventStatistics::incrementBookmarkCount);
-
 		if (!request.imageUrlList().isEmpty()) {
 			imageCommandService.addImageToUserPlace(request, user, userPlace);
 		}
@@ -103,6 +95,7 @@ public class UserPlaceCommandService {
 		user.addUserPlace(userPlace);
 		commonPlace.addUserPlace(userPlace);
 		userPlaceRepository.save(userPlace);
+		notificationCommandService.createNotificationOfASavedPlace(user, commonPlace, userPlace);
 	}
 
 	public boolean duplicatePlace(Long userId, PlaceRequestDto request) {
@@ -110,7 +103,8 @@ public class UserPlaceCommandService {
 	}
 
 	public PlaceResponseDto updateUserPlaceImage(Long userPlaceId, List<MultipartFile> newImageList) {
-		UserPlace userPlace = userPlaceRepository.findById(userPlaceId).orElseThrow(() -> new PlaceException(USER_PLACE_NOT_FOUND));
+		UserPlace userPlace = userPlaceRepository.findById(userPlaceId)
+			.orElseThrow(() -> new PlaceException(USER_PLACE_NOT_FOUND));
 
 		List<Image> existingImages = userPlace.getImages();
 		if (newImageList == null || newImageList.isEmpty()) {
@@ -126,7 +120,8 @@ public class UserPlaceCommandService {
 			.toList(); // 변경된 URL 리스트 저장
 
 		// 업데이트된 URL을 한 번에 반영
-		IntStream.range(0, updatedImageUrls.size()).forEach(i -> existingImages.get(i).updateUrl(updatedImageUrls.get(i)));
+		IntStream.range(0, updatedImageUrls.size())
+			.forEach(i -> existingImages.get(i).updateUrl(updatedImageUrls.get(i)));
 
 		// 새로운 이미지 추가 (Directory.EVENT.getPath() 사용)
 		if (newImageList.size() > existingImages.size()) {
@@ -137,7 +132,6 @@ public class UserPlaceCommandService {
 				extraImages.forEach(userPlace::addImage);
 			}
 		}
-
 
 		return userPlaceConverter.toResponse(userPlace);
 	}

--- a/src/main/java/com/adit/backend/domain/place/service/query/CommonPlaceQueryService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/query/CommonPlaceQueryService.java
@@ -73,6 +73,4 @@ public class CommonPlaceQueryService {
 			.sorted((a1, b1) -> friendsCommonplace.get(b1) - friendsCommonplace.get(a1))
 			.toList();
 	}
-
-
 }

--- a/src/main/java/com/adit/backend/domain/place/service/query/UserPlaceQueryService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/query/UserPlaceQueryService.java
@@ -4,7 +4,6 @@ import static com.adit.backend.global.error.GlobalErrorCode.*;
 import static com.adit.backend.global.util.MapUtil.*;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -20,11 +19,9 @@ import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.UserPlace;
 import com.adit.backend.domain.place.exception.PlaceException;
 import com.adit.backend.domain.place.repository.UserPlaceRepository;
-import com.adit.backend.domain.user.converter.UserConverter;
 import com.adit.backend.domain.user.dto.response.UserResponse;
-import com.adit.backend.domain.user.exception.UserException;
+import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.repository.FriendshipRepository;
-import com.adit.backend.domain.user.repository.UserRepository;
 import com.adit.backend.domain.user.service.query.UserQueryService;
 
 import lombok.RequiredArgsConstructor;
@@ -128,5 +125,10 @@ public class UserPlaceQueryService {
 			response.put(commonPlaceConverter.commonPlaceToResponse(commonPlace), friendInfoList);
 		});
 		return response;
+	}
+
+	public List<UserPlace> findRelatedUserPlace(User user, CommonPlace commonPlace) {
+		return userPlaceRepository.findAllFriendsUserPlace(user.getId(), commonPlace.getId())
+			.orElseThrow(() -> new PlaceException(USER_PLACE_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/adit/backend/domain/user/converter/FriendConverter.java
+++ b/src/main/java/com/adit/backend/domain/user/converter/FriendConverter.java
@@ -2,33 +2,33 @@ package com.adit.backend.domain.user.converter;
 
 import org.springframework.stereotype.Component;
 
-import com.adit.backend.domain.user.dto.request.FriendRequestDto;
 import com.adit.backend.domain.user.dto.response.FriendshipResponseDto;
 import com.adit.backend.domain.user.entity.Friendship;
+import com.adit.backend.domain.user.entity.User;
 
 @Component
 public class FriendConverter {
 
 	public FriendshipResponseDto toResponse(Friendship friendship) {
 		return FriendshipResponseDto.builder()
-			.fromUser(friendship.getFromUser())
-			.toUser(friendship.getToUser())
+			.fromUserId(friendship.getFromUser().getId())
+			.toUserId(friendship.getToUser().getId())
 			.status(friendship.getStatus())
 			.build();
 	}
 
-	public Friendship toForwardEntity(FriendRequestDto friendRequestDto) {
+	public Friendship toForwardEntity(User fromUser, User toUser) {
 		return Friendship.builder()
-			.fromUser(friendRequestDto.fromUser())
-			.toUser(friendRequestDto.toUser())
+			.fromUser(fromUser)
+			.toUser(toUser)
 			.status(true)
 			.build();
 	}
 
-	public Friendship toReverseEntity(FriendRequestDto friendRequestDto) {
+	public Friendship toReverseEntity(User fromUser, User toUser) {
 		return Friendship.builder()
-			.fromUser(friendRequestDto.toUser())
-			.toUser(friendRequestDto.fromUser())
+			.fromUser(fromUser)
+			.toUser(toUser)
 			.status(false)
 			.build();
 	}

--- a/src/main/java/com/adit/backend/domain/user/converter/FriendConverter.java
+++ b/src/main/java/com/adit/backend/domain/user/converter/FriendConverter.java
@@ -17,19 +17,11 @@ public class FriendConverter {
 			.build();
 	}
 
-	public Friendship toForwardEntity(User fromUser, User toUser) {
+	public Friendship toEntity(User FromUser, User toUser, Boolean status) {
 		return Friendship.builder()
-			.fromUser(fromUser)
+			.fromUser(FromUser)
 			.toUser(toUser)
-			.status(true)
-			.build();
-	}
-
-	public Friendship toReverseEntity(User fromUser, User toUser) {
-		return Friendship.builder()
-			.fromUser(fromUser)
-			.toUser(toUser)
-			.status(false)
+			.status(status)
 			.build();
 	}
 }

--- a/src/main/java/com/adit/backend/domain/user/dto/request/FriendRequestDto.java
+++ b/src/main/java/com/adit/backend/domain/user/dto/request/FriendRequestDto.java
@@ -1,13 +1,12 @@
 package com.adit.backend.domain.user.dto.request;
 
 import com.adit.backend.domain.user.entity.Friendship;
-import com.adit.backend.domain.user.entity.User;
 
 import jakarta.validation.constraints.NotNull;
 
 /**
  * DTO for {@link Friendship}
  */
-public record FriendRequestDto(@NotNull(message = "From User ID must not be null") User fromUser,
-							   @NotNull(message = "To User ID must not be null") User toUser) {
+public record FriendRequestDto(@NotNull(message = "From User ID must not be null") Long fromUserId,
+							   @NotNull(message = "To User ID must not be null") Long toUserId) {
 }

--- a/src/main/java/com/adit/backend/domain/user/dto/response/FriendshipResponseDto.java
+++ b/src/main/java/com/adit/backend/domain/user/dto/response/FriendshipResponseDto.java
@@ -3,7 +3,6 @@ package com.adit.backend.domain.user.dto.response;
 import java.io.Serializable;
 
 import com.adit.backend.domain.user.entity.Friendship;
-import com.adit.backend.domain.user.entity.User;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -12,8 +11,8 @@ import lombok.Builder;
  * DTO for {@link Friendship}
  */
 @Builder
-public record FriendshipResponseDto(Long id, @NotNull(message = "From User ID must not be nul") User fromUser,
-									@NotNull(message = "To User ID must not be nul") User toUser, Boolean status)
+public record FriendshipResponseDto(Long id, @NotNull(message = "From User ID must not be nul") Long fromUserId,
+									@NotNull(message = "To User ID must not be nul") Long toUserId, Boolean status)
 	implements Serializable {
 
 }

--- a/src/main/java/com/adit/backend/domain/user/service/command/FriendCommandService.java
+++ b/src/main/java/com/adit/backend/domain/user/service/command/FriendCommandService.java
@@ -7,17 +7,15 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.adit.backend.domain.notification.converter.NotificationEventConverter;
-import com.adit.backend.domain.notification.event.NotificationEvent;
-import com.adit.backend.domain.notification.service.command.NotificationCommandService;
 import com.adit.backend.domain.user.converter.FriendConverter;
 import com.adit.backend.domain.user.dto.request.FriendRequestDto;
 import com.adit.backend.domain.user.dto.response.FriendshipResponseDto;
 import com.adit.backend.domain.user.entity.Friendship;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.exception.FriendShipException;
+import com.adit.backend.domain.user.exception.UserException;
 import com.adit.backend.domain.user.repository.FriendshipRepository;
-import com.adit.backend.domain.user.service.query.UserQueryService;
+import com.adit.backend.domain.user.repository.UserRepository;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -29,26 +27,22 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class FriendCommandService {
 
-	private final NotificationEventConverter eventConverter;
-	private final UserQueryService userQueryService;
+	private final UserRepository userRepository;
 	private final FriendshipRepository friendshipRepository;
 	private final FriendConverter friendConverter;
-	private final NotificationCommandService notificationCommandService;
 
 	// 친구 요청 보내기
 	public FriendshipResponseDto sendFriendRequest(FriendRequestDto requestDto) {
+		User FromUser = userRepository.findById(requestDto.fromUserId()).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+		User toUser = userRepository.findById(requestDto.toUserId()).orElseThrow(() -> new UserException(USER_NOT_FOUND));
 		// 친구 요청(정방향)
-		User fromUser = userQueryService.findUserById(requestDto.fromUserId());
-		User toUser = userQueryService.findUserById(requestDto.toUserId());
-
-		Friendship forwardRequest = friendConverter.toForwardEntity(fromUser, toUser);
+		Friendship forwardRequest = friendConverter.toEntity(FromUser, toUser, true);
 		// 친구 요청(역방향)
-		Friendship reverseRequest = friendConverter.toReverseEntity(fromUser, toUser);
+		Friendship reverseRequest = friendConverter.toEntity(toUser, FromUser, false);
 
 		Friendship savedForwardRequest = friendshipRepository.save(forwardRequest);
 		friendshipRepository.save(reverseRequest);
-		NotificationEvent event = eventConverter.toRequestEvent(savedForwardRequest);
-		notificationCommandService.sendNotification(event);
+
 		return friendConverter.toResponse(savedForwardRequest);
 	}
 
@@ -56,9 +50,8 @@ public class FriendCommandService {
 	public void acceptFriendRequest(Long requestId) {
 		Friendship friendRequest = friendshipRepository.findById(requestId)
 			.orElseThrow(() -> new FriendShipException(FRIEND_REQUEST_NOT_FOUND));
+
 		friendRequest.acceptRequest();
-		NotificationEvent event = eventConverter.toAcceptEvent(friendRequest);
-		notificationCommandService.sendNotification(event);
 	}
 
 	// 친구 요청 거절

--- a/src/main/java/com/adit/backend/domain/user/service/command/FriendCommandService.java
+++ b/src/main/java/com/adit/backend/domain/user/service/command/FriendCommandService.java
@@ -7,6 +7,9 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.adit.backend.domain.notification.converter.NotificationEventConverter;
+import com.adit.backend.domain.notification.event.NotificationEvent;
+import com.adit.backend.domain.notification.service.command.NotificationCommandService;
 import com.adit.backend.domain.user.converter.FriendConverter;
 import com.adit.backend.domain.user.dto.request.FriendRequestDto;
 import com.adit.backend.domain.user.dto.response.FriendshipResponseDto;
@@ -14,7 +17,7 @@ import com.adit.backend.domain.user.entity.Friendship;
 import com.adit.backend.domain.user.entity.User;
 import com.adit.backend.domain.user.exception.FriendShipException;
 import com.adit.backend.domain.user.repository.FriendshipRepository;
-import com.adit.backend.domain.user.repository.UserRepository;
+import com.adit.backend.domain.user.service.query.UserQueryService;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -26,20 +29,26 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class FriendCommandService {
 
-	private final UserRepository userRepository;
+	private final NotificationEventConverter eventConverter;
+	private final UserQueryService userQueryService;
 	private final FriendshipRepository friendshipRepository;
 	private final FriendConverter friendConverter;
+	private final NotificationCommandService notificationCommandService;
 
 	// 친구 요청 보내기
 	public FriendshipResponseDto sendFriendRequest(FriendRequestDto requestDto) {
 		// 친구 요청(정방향)
-		Friendship forwardRequest = friendConverter.toForwardEntity(requestDto);
+		User fromUser = userQueryService.findUserById(requestDto.fromUserId());
+		User toUser = userQueryService.findUserById(requestDto.toUserId());
+
+		Friendship forwardRequest = friendConverter.toForwardEntity(fromUser, toUser);
 		// 친구 요청(역방향)
-		Friendship reverseRequest = friendConverter.toReverseEntity(requestDto);
+		Friendship reverseRequest = friendConverter.toReverseEntity(fromUser, toUser);
 
 		Friendship savedForwardRequest = friendshipRepository.save(forwardRequest);
 		friendshipRepository.save(reverseRequest);
-
+		NotificationEvent event = eventConverter.toRequestEvent(savedForwardRequest);
+		notificationCommandService.sendNotification(event);
 		return friendConverter.toResponse(savedForwardRequest);
 	}
 
@@ -47,8 +56,9 @@ public class FriendCommandService {
 	public void acceptFriendRequest(Long requestId) {
 		Friendship friendRequest = friendshipRepository.findById(requestId)
 			.orElseThrow(() -> new FriendShipException(FRIEND_REQUEST_NOT_FOUND));
-
 		friendRequest.acceptRequest();
+		NotificationEvent event = eventConverter.toAcceptEvent(friendRequest);
+		notificationCommandService.sendNotification(event);
 	}
 
 	// 친구 요청 거절

--- a/src/main/java/com/adit/backend/domain/user/service/command/FriendCommandService.java
+++ b/src/main/java/com/adit/backend/domain/user/service/command/FriendCommandService.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.adit.backend.domain.notification.service.NotificationGenerationService;
+import com.adit.backend.domain.notification.service.command.NotificationCommandService;
 import com.adit.backend.domain.user.converter.FriendConverter;
 import com.adit.backend.domain.user.dto.request.FriendRequestDto;
 import com.adit.backend.domain.user.dto.response.FriendshipResponseDto;
@@ -29,12 +31,16 @@ public class FriendCommandService {
 
 	private final UserRepository userRepository;
 	private final FriendshipRepository friendshipRepository;
+	private final NotificationCommandService notificationCommandService;
 	private final FriendConverter friendConverter;
+	private final NotificationGenerationService notificationGenerationService;
 
 	// 친구 요청 보내기
 	public FriendshipResponseDto sendFriendRequest(FriendRequestDto requestDto) {
-		User FromUser = userRepository.findById(requestDto.fromUserId()).orElseThrow(() -> new UserException(USER_NOT_FOUND));
-		User toUser = userRepository.findById(requestDto.toUserId()).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+		User FromUser = userRepository.findById(requestDto.fromUserId())
+			.orElseThrow(() -> new UserException(USER_NOT_FOUND));
+		User toUser = userRepository.findById(requestDto.toUserId())
+			.orElseThrow(() -> new UserException(USER_NOT_FOUND));
 		// 친구 요청(정방향)
 		Friendship forwardRequest = friendConverter.toEntity(FromUser, toUser, true);
 		// 친구 요청(역방향)
@@ -42,7 +48,7 @@ public class FriendCommandService {
 
 		Friendship savedForwardRequest = friendshipRepository.save(forwardRequest);
 		friendshipRepository.save(reverseRequest);
-
+		notificationGenerationService.createNotificationOfAFriendRequest(savedForwardRequest);
 		return friendConverter.toResponse(savedForwardRequest);
 	}
 
@@ -50,8 +56,8 @@ public class FriendCommandService {
 	public void acceptFriendRequest(Long requestId) {
 		Friendship friendRequest = friendshipRepository.findById(requestId)
 			.orElseThrow(() -> new FriendShipException(FRIEND_REQUEST_NOT_FOUND));
-
 		friendRequest.acceptRequest();
+		notificationGenerationService.createNotificationOfAFriendAccept(friendRequest);
 	}
 
 	// 친구 요청 거절

--- a/src/main/java/com/adit/backend/global/config/CorsConfig.java
+++ b/src/main/java/com/adit/backend/global/config/CorsConfig.java
@@ -13,6 +13,7 @@ public class CorsConfig {
 
 	public static final String SERVER_URL = "http://ec2-3-39-228-156.ap-northeast-2.compute.amazonaws.com:8080";
 	public static final String FRONT_URL = "http://localhost:3000";
+	public static final String LOCALHOST = "http://localhost:8080";
 
 	@Bean
 	public CorsFilter corsFilter() {
@@ -22,6 +23,7 @@ public class CorsConfig {
 	        config.setAllowCredentials(true);
 	        config.addAllowedOrigin(SERVER_URL);
 	        config.addAllowedOrigin(FRONT_URL);
+			config.addAllowedOrigin(LOCALHOST);
 	        config.addAllowedHeader("*");
 	        config.addAllowedMethod("*");
 	        config.setExposedHeaders(List.of(

--- a/src/main/java/com/adit/backend/global/config/CorsConfig.java
+++ b/src/main/java/com/adit/backend/global/config/CorsConfig.java
@@ -11,31 +11,33 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 public class CorsConfig {
 
-	public static final String SERVER_URL = "http://ec2-3-39-228-156.ap-northeast-2.compute.amazonaws.com:8080";
-	public static final String FRONT_URL = "http://localhost:3000";
-	public static final String LOCALHOST = "http://localhost:8080";
+	private static final String SERVER_URL = "https://odit.store";
+	private static final String FRONT_URL = "https://odit-lilac.vercel.app";
+	private static final String FRONT_LOCALHOST_URL = "http://localhost:3000";
+	private static final String SERVER_LOCALHOST_URL = "http://localhost:8080";
 
 	@Bean
 	public CorsFilter corsFilter() {
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 
 		CorsConfiguration config = new CorsConfiguration();
-	        config.setAllowCredentials(true);
-	        config.addAllowedOrigin(SERVER_URL);
-	        config.addAllowedOrigin(FRONT_URL);
-			config.addAllowedOrigin(LOCALHOST);
-	        config.addAllowedHeader("*");
-	        config.addAllowedMethod("*");
-	        config.setExposedHeaders(List.of(
-	            "accessToken", 
-	            "Authorization", 
-	            "Authorization-refresh"
-	        ));
-	        config.addExposedHeader("Set-Cookie");
-	        
-	        // 모든 엔드포인트에 대해 CORS 설정 적용
-	        source.registerCorsConfiguration("/**", config);
-	        return new CorsFilter(source);
+		config.setAllowCredentials(true);
+		config.addAllowedOrigin(SERVER_URL);
+		config.addAllowedOrigin(FRONT_URL);
+		config.addAllowedOrigin(FRONT_LOCALHOST_URL);
+		config.addAllowedOrigin(SERVER_LOCALHOST_URL);
+		config.addAllowedHeader("*");
+		config.addAllowedMethod("*");
+		config.setExposedHeaders(List.of(
+			"accessToken",
+			"Authorization",
+			"Authorization-refresh"
+		));
+		config.addExposedHeader("Set-Cookie");
+
+		// 모든 엔드포인트에 대해 CORS 설정 적용
+		source.registerCorsConfiguration("/**", config);
+		return new CorsFilter(source);
 	}
 }
 

--- a/src/main/java/com/adit/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/adit/backend/global/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -39,7 +40,7 @@ public class RedisConfig {
 
 		// Key-Value 형태로 직렬화를 수행합니다.
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
 
 		// Hash Key-Value 형태로 직렬화를 수행합니다.
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());

--- a/src/main/java/com/adit/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/adit/backend/global/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -48,5 +49,13 @@ public class RedisConfig {
 		redisTemplate.setDefaultSerializer(new StringRedisSerializer());
 
 		return redisTemplate;
+	}
+
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(
+		RedisConnectionFactory redisConnectionFactory) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(redisConnectionFactory);
+		return container;
 	}
 }

--- a/src/main/java/com/adit/backend/global/error/GlobalErrorCode.java
+++ b/src/main/java/com/adit/backend/global/error/GlobalErrorCode.java
@@ -30,6 +30,7 @@ public enum GlobalErrorCode implements ErrorCode {
 	ILLEGAL_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "GBL-011", "인자가 유효하지 않습니다."),
 	SERVLET_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GBL-012", "서블릿 처리 중 오류가 발생했습니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GBL-013", "서버 내부 오류가 발생했습니다."),
+	AUTHENTICATION_FALIED(UNAUTHORIZED, "GBL-014", "인증에 실패하였습니다."),
 
 	/********************************** Transaction Domain **********************************/
 	INSERT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "TRX-001", "Insert Transaction Error Exception"),

--- a/src/main/java/com/adit/backend/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/adit/backend/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -63,8 +63,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
 		ZonedDateTime expirationTime = seoulTime.plusSeconds(refreshTokenExpirationAt);
 		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
-		//cookie.setSecure(true);
-		//cookie.setHttpOnly(true);
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
 		response.addCookie(cookie);
 
 		// Role 정보를 응답 본문에 추가

--- a/src/main/java/com/adit/backend/global/util/CookieUtils.java
+++ b/src/main/java/com/adit/backend/global/util/CookieUtils.java
@@ -27,7 +27,8 @@ public class CookieUtils {
 	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
 		Cookie cookie = new Cookie(name, value);
 		cookie.setPath("/");
-		//cookie.setHttpOnly(true);
+		cookie.setHttpOnly(true);
+		cookie.setHttpOnly(true);
 		cookie.setMaxAge(maxAge);
 		response.addCookie(cookie);
 	}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,4 +27,4 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 30s
 redirect:
-  url: ${FRONT_LOCAL_URL}/login/kakao
+  url: ${FRONT_URL}/login/kakao

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,7 +82,8 @@ cloud:
     stack:
       auto: true
 
-
+sse:
+  timeout: 6000
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 💡 작업 내용

- Notification 엔티티 구조 변경 및 Response 구조 개선  
- Redis pub/sub 기능 지원을 위한 설정 추가  
- SSE(SERVER-SENT EVENTS) 기반 알림 시스템 구현  
- 알림 생성 및 비동기 처리 기능 추가  
- 알림 카테고리별 조회 및 Response DTO 개선  
- SSE 구독 및 취소 기능 구현  

## 💡 자세한 설명


1. **Notification 엔티티 구조 변경 및 Response 개선**  

2. **Redis pub/sub 설정 추가**  
   - Redis를 활용한 pub/sub 메시지 브로커 설정을 추가하여 실시간 알림 전송을 지원

3. **SSE 기반 알림 시스템 구현**  
   - SSE를 사용하여 클라이언트가 서버와 구독 관계를 유지하며 실시간 알림을 받을 수 있도록 구현

4. **알림 생성 및 비동기 처리 기능 추가**  
   - 장소 저장, 친구 요청/수락 등 다양한 이벤트에 대한 알림 생성 로직을 추가하고, 비동기 처리로 서버 응답 속도를 최적화

5. **알림 카테고리별 조회 및 쿼리 개선**  
   - 최근 7일 내 알림, 카테고리별 알림 조회 API를 추가하고, 관련 쿼리를 최적화하여 성능을 개선
  
6. **코드 리팩토링 및 동기화**  
   - 코드 서식을 정리하고, conflict 방지를 위해 develop 브랜치와 동기화 작업을 진행

- 장소 미방문 알림, 장소 기간 미 입력, 이벤트 시작일 알림은 이후 `Spring Scheduling`을 이용하여 추가 구현 예정입니다.
## 📗 참고 자료 (선택)
- 관련 이슈 : close #64

## 📢 리뷰 요구 사항 (선택)


## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?  
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?  
- [x] Assignees, Reviewers, Labels 를 등록했나요?  
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?  
- [x] 불필요한 코드는 제거했나요?
