### PR TITLE
[Refactor] 이미지 추출 정확도 향상, 서비스 중단 방지 적용 

### DIFF
--- a/src/main/java/com/adit/backend/infra/crawler/WebContentCrawler.java
+++ b/src/main/java/com/adit/backend/infra/crawler/WebContentCrawler.java
@@ -99,7 +99,6 @@ public class WebContentCrawler {
 	public static List<String> extractImageSrcList(Elements elements) {
 		if (elements == null) {
 			log.error("[Crawl] 이미지 추출을 위한 요소가 null");
-			throw new CrawlingException(GlobalErrorCode.IMAGE_EXTRACTION_FAILED);
 		}
 		try {
 			List<String> imageSrcList = new ArrayList<>();

--- a/src/main/java/com/adit/backend/infra/crawler/WebContentCrawler.java
+++ b/src/main/java/com/adit/backend/infra/crawler/WebContentCrawler.java
@@ -99,11 +99,13 @@ public class WebContentCrawler {
 	public static List<String> extractImageSrcList(Elements elements) {
 		if (elements == null) {
 			log.error("[Crawl] 이미지 추출을 위한 요소가 null");
+			throw new CrawlingException(GlobalErrorCode.IMAGE_EXTRACTION_FAILED);
 		}
 		try {
 			List<String> imageSrcList = new ArrayList<>();
 			Elements imgElements = elements.select("img");
 			for (Element img : imgElements) {
+				// 우선 data-lazy-src, data-origin, src 순으로 URL을 가져옵니다.
 				String highResUrl = img.attr("data-lazy-src");
 				if (highResUrl.isEmpty()) {
 					highResUrl = img.attr("data-origin");
@@ -111,8 +113,14 @@ public class WebContentCrawler {
 				if (highResUrl.isEmpty()) {
 					highResUrl = img.attr("src");
 				}
+				// URL에 "?type=" 파라미터가 있으면 제거
 				if (highResUrl.contains("?type=")) {
 					highResUrl = highResUrl.split("\\?type=")[0];
+				}
+				// 추출된 URL이 비어있지 않으면, 제외해야 할 패턴이면 건너뜁니다.
+				if (!highResUrl.isEmpty() && isExcludedUrl(highResUrl)) {
+					log.debug("[Crawl] 제외된 이미지 URL: {}", highResUrl);
+					continue;
 				}
 				if (!highResUrl.isEmpty()) {
 					imageSrcList.add(highResUrl + "?type=w966");
@@ -124,6 +132,14 @@ public class WebContentCrawler {
 			throw new CrawlingException(GlobalErrorCode.IMAGE_EXTRACTION_FAILED);
 		}
 	}
+
+	private static boolean isExcludedUrl(String url) {
+		return url.contains("dthumb-phinf.pstatic.net")
+			|| url.contains("blogimgs.pstatic.net/nblog/quickeditor")
+			|| url.contains("storep-phinf.pstatic.net")
+			|| url.contains("blogpfthumb-phinf.pstatic.net");
+	}
+
 
 	public static String extractPlaceInfo(Document document) {
 		StringBuilder placeBuilder = new StringBuilder();

--- a/src/main/java/com/adit/backend/infra/crawler/WebContentCrawler.java
+++ b/src/main/java/com/adit/backend/infra/crawler/WebContentCrawler.java
@@ -187,7 +187,6 @@ public class WebContentCrawler {
 				log.debug("[Crawl] 제목 추출 완료: {}", title);
 			} else {
 				log.warn("[Crawl] 제목 추출 실패: {}", document.location());
-				throw new CrawlingException(GlobalErrorCode.TITLE_EXTRACTION_FAILED);
 			}
 		} catch (Exception e) {
 			log.error("[Crawl] 제목 추출 중 오류 발생: {}", e.getMessage());


### PR DESCRIPTION
## 💡 작업 내용
- 크롤링 중단 방지를 위한 불필요 예외 처리 제거
- 특정 플랫폼의 불필요 이미지 크롤링 방지를 위한 제외 패턴 추가 

## 💡 자세한 설명
1. **불필요 예외 처리 제거**
  - 기존 제목, 이미지 데이터가 담긴 Element를 찾지 못하면 예외처리를 진행하였지만 크롤링의 중단을 방지하기 위하여 제거
2. **불필요 이미지 크롤링 방지를 위한 제외 패턴 추가**
  - PC 환경의 네이버 블로그 플랫폼 크롤링 진행시 불필요한 gif 파일과 temp 파일이 같이 imgUrlList에 담겨서 오는 문제 발생
  - 해당 파일 패턴을 탐색하여 방지하도록 제외 패턴 적용

> 지정한 특정 플랫폼을 제외한 특정 URL에서는 이미지가 담겨오지 않는 문제가 있어 이를 해결해보려고 했지만 동적 웹페이지에 담긴 이미지를 Jsoup으로 가져오는건 불가능하였다. 이후 기능이 확장된다면 별도의 Selenium을 이용한 크롤링 서버를 구축하여 지원 가능한 플랫폼을 확장 할 수 있을 것 같다.
## 📗 참고 자료 (선택)
- close #80
## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
