### PR TITLE
[Feat] 북마크 장소저장 API 기능 구현

### DIFF
--- a/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/adit/backend/domain/image/service/command/ImageCommandService.java
@@ -72,6 +72,14 @@ public class ImageCommandService {
 
 	}
 
+	//UserPlace에 이미지 연관관계 추가 후 저장 2
+	public void addImageToUserPlace(CommonPlace commonPlace, User user, UserPlace userPlace) {
+		List<Image> imageList = s3Service.uploadFile(commonPlace.getImages().stream().map(Image::getUrl).toList(), USER.getPath() + user.getId()).join();
+		imageList.forEach(userPlace::addImage);
+		imageRepository.saveAll(imageList);
+
+	}
+
 	// CommonPlace에 이미지 연관관계 추가 후 저장
 	public void addImageToCommonPlace(PlaceRequestDto request, CommonPlace commonPlace) {
 		List<Image> imageList = s3Service.uploadFile(request.imageUrlList(), PLACE.getPath()).join();

--- a/src/main/java/com/adit/backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/adit/backend/domain/place/controller/PlaceController.java
@@ -179,4 +179,13 @@ public class PlaceController {
 		PlaceResponseDto placeResponseDto = userPlaceCommandService.updateUserPlaceImage(userPlaceId, multipartFile);
 		return ResponseEntity.ok(ApiResponse.success(placeResponseDto));
 	}
+
+	//북마크 장소 저장 API
+	@Operation(summary = "북마크 장소 저장", description = "commonPlaceId에 해당하는 장소를 userPlace 에 저장")
+	@PostMapping("/{commonPlaceId}/bookMark")
+	public ResponseEntity<ApiResponse<PlaceResponseDto>> savedCommonPlace(@PathVariable Long commonPlaceId ,
+		@AuthenticationPrincipal(expression = "user") User user){
+		PlaceResponseDto placeResponseDto = userPlaceCommandService.savedCommonPlace(commonPlaceId, user.getId());
+		return ResponseEntity.ok(ApiResponse.success(placeResponseDto));
+	}
 }

--- a/src/main/java/com/adit/backend/domain/place/converter/UserPlaceConverter.java
+++ b/src/main/java/com/adit/backend/domain/place/converter/UserPlaceConverter.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Component;
 import com.adit.backend.domain.image.entity.Image;
 import com.adit.backend.domain.place.dto.request.PlaceRequestDto;
 import com.adit.backend.domain.place.dto.response.PlaceResponseDto;
+import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.UserPlace;
+import com.adit.backend.domain.user.entity.User;
 
 @Component
 public class UserPlaceConverter {
@@ -17,6 +19,12 @@ public class UserPlaceConverter {
 	public UserPlace toEntity(PlaceRequestDto request) {
 		return UserPlace.builder()
 			.memo(request.memo())
+			.visited(false)
+			.build();
+	}
+
+	public UserPlace toEntity(CommonPlace commonPlace){
+		return UserPlace.builder()
 			.visited(false)
 			.build();
 	}

--- a/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
@@ -99,7 +99,7 @@ public class UserPlaceCommandService {
 	public void duplicatePlace(Long userId, String requestUrl) {
 		if( userPlaceRepository.findDuplicatePlace(userId, requestUrl) != null){
 			throw new PlaceException(USER_PLACE_DUPLICATE);
-		};
+		}
 	}
 
 	public PlaceResponseDto updateUserPlaceImage(Long userPlaceId, List<MultipartFile> newImageList) {

--- a/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
@@ -144,6 +144,7 @@ public class UserPlaceCommandService {
 		}
 		UserPlace userPlace = userPlaceConverter.toEntity(commonPlace);
 		saveUserPlaceRelation(user, commonPlace, userPlace);
+		placeStatisticsCommandService.saveOrCount(commonPlace);
 
 		return commonPlaceConverter.userPlaceToResponse(userPlace);
 	}

--- a/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
@@ -50,9 +50,7 @@ public class UserPlaceCommandService {
 	// 장소 저장시, EventStatistics.bookmarkCount 증가
 	public PlaceResponseDto createUserPlace(Long userId, PlaceRequestDto request) {
 		//장소 중복 검사
-		if (!duplicatePlace(userId, request.url())) {
-			throw new PlaceException(USER_PLACE_DUPLICATE);
-		}
+		duplicatePlace(userId, request.url());
 		User user = userQueryService.findUserById(userId);
 		CommonPlace commonPlace = commonPlaceCommandService.saveOrFindCommonPlace(request);
 		UserPlace userPlace = userPlaceConverter.toEntity(request);
@@ -98,8 +96,10 @@ public class UserPlaceCommandService {
 		notificationGenerationService.createNotificationOfASavedPlace(user, commonPlace, userPlace);
 	}
 
-	public boolean duplicatePlace(Long userId, String requestUrl) {
-		return userPlaceRepository.findDuplicatePlace(userId, requestUrl) == null;
+	public void duplicatePlace(Long userId, String requestUrl) {
+		if( userPlaceRepository.findDuplicatePlace(userId, requestUrl) != null){
+			throw new PlaceException(USER_PLACE_DUPLICATE);
+		};
 	}
 
 	public PlaceResponseDto updateUserPlaceImage(Long userPlaceId, List<MultipartFile> newImageList) {
@@ -139,12 +139,13 @@ public class UserPlaceCommandService {
 	public PlaceResponseDto savedCommonPlace(Long commonPlaceId, Long userId) {
 		CommonPlace commonPlace = commonPlaceRepository.findById(commonPlaceId).orElseThrow(() -> new PlaceException(COMMON_PLACE_NOT_FOUND));
 		User user = userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
-		if (!duplicatePlace(userId, commonPlace.getUrl())){
-			throw new PlaceException(USER_PLACE_DUPLICATE);
-		}
+		duplicatePlace(userId, commonPlace.getUrl());
 		UserPlace userPlace = userPlaceConverter.toEntity(commonPlace);
 		saveUserPlaceRelation(user, commonPlace, userPlace);
 		placeStatisticsCommandService.saveOrCount(commonPlace);
+		if (!commonPlace.getImages().stream().map(Image::getUrl).toList().isEmpty()) {
+			imageCommandService.addImageToUserPlace(commonPlace, user, userPlace);
+		}
 
 		return commonPlaceConverter.userPlaceToResponse(userPlace);
 	}

--- a/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
+++ b/src/main/java/com/adit/backend/domain/place/service/command/UserPlaceCommandService.java
@@ -20,8 +20,11 @@ import com.adit.backend.domain.place.dto.response.PlaceResponseDto;
 import com.adit.backend.domain.place.entity.CommonPlace;
 import com.adit.backend.domain.place.entity.UserPlace;
 import com.adit.backend.domain.place.exception.PlaceException;
+import com.adit.backend.domain.place.repository.CommonPlaceRepository;
 import com.adit.backend.domain.place.repository.UserPlaceRepository;
 import com.adit.backend.domain.user.entity.User;
+import com.adit.backend.domain.user.exception.UserException;
+import com.adit.backend.domain.user.repository.UserRepository;
 import com.adit.backend.domain.user.service.query.UserQueryService;
 import com.adit.backend.global.error.exception.BusinessException;
 
@@ -33,7 +36,8 @@ import lombok.RequiredArgsConstructor;
 public class UserPlaceCommandService {
 
 	private final UserPlaceRepository userPlaceRepository;
-
+	private final CommonPlaceRepository commonPlaceRepository;
+	private final UserRepository userRepository;
 	private final UserQueryService userQueryService;
 	private final CommonPlaceCommandService commonPlaceCommandService;
 	private final ImageCommandService imageCommandService;
@@ -46,7 +50,7 @@ public class UserPlaceCommandService {
 	// 장소 저장시, EventStatistics.bookmarkCount 증가
 	public PlaceResponseDto createUserPlace(Long userId, PlaceRequestDto request) {
 		//장소 중복 검사
-		if (!duplicatePlace(userId, request)) {
+		if (!duplicatePlace(userId, request.url())) {
 			throw new PlaceException(USER_PLACE_DUPLICATE);
 		}
 		User user = userQueryService.findUserById(userId);
@@ -94,8 +98,8 @@ public class UserPlaceCommandService {
 		notificationGenerationService.createNotificationOfASavedPlace(user, commonPlace, userPlace);
 	}
 
-	public boolean duplicatePlace(Long userId, PlaceRequestDto request) {
-		return userPlaceRepository.findDuplicatePlace(userId, request.url()) == null;
+	public boolean duplicatePlace(Long userId, String requestUrl) {
+		return userPlaceRepository.findDuplicatePlace(userId, requestUrl) == null;
 	}
 
 	public PlaceResponseDto updateUserPlaceImage(Long userPlaceId, List<MultipartFile> newImageList) {
@@ -130,5 +134,17 @@ public class UserPlaceCommandService {
 		}
 
 		return userPlaceConverter.toResponse(userPlace);
+	}
+
+	public PlaceResponseDto savedCommonPlace(Long commonPlaceId, Long userId) {
+		CommonPlace commonPlace = commonPlaceRepository.findById(commonPlaceId).orElseThrow(() -> new PlaceException(COMMON_PLACE_NOT_FOUND));
+		User user = userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+		if (!duplicatePlace(userId, commonPlace.getUrl())){
+			throw new PlaceException(USER_PLACE_DUPLICATE);
+		}
+		UserPlace userPlace = userPlaceConverter.toEntity(commonPlace);
+		saveUserPlaceRelation(user, commonPlace, userPlace);
+
+		return commonPlaceConverter.userPlaceToResponse(userPlace);
 	}
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 북마크 장소저장 API 구현

## 💡 자세한 설명
원래는 링크 추출이 되었을 때, commonPlace와 userPlace를 함께 저장하는 API만 존재 했다. 
하지만 아래의 사진과 같은 경우, 북마크를 클릭하면 해당 사용자의 장소에도 저장되는 기능을 제공해야 하기 때문에 commonPlaceId를 가지고 userPlace 에 장소를 저장하는 API도 추가로 구현했다. 

## 📗 참고 자료 (선택)
<img width="195" alt="KakaoTalk_20250218_202442170" src="https://github.com/user-attachments/assets/a4331891-41dc-4497-ab9c-6cca5ac8f811" />


## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
