### PR TITLE
[Fix] Spring AI 1.0.0-M6 버전 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ repositories {
         url = 'https://central.sonatype.com/repository/maven-snapshots/'
     }
 }
+ext {
+    set('springAiVersion', "1.0.0-M6")
+}
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,10 @@ repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }
     maven { url 'https://repo.spring.io/snapshot' }
-}
-
-ext {
-    set('springAiVersion', "1.0.0-SNAPSHOT")
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+    }
 }
 
 dependencies {

--- a/src/main/java/com/adit/backend/global/config/AiConfig.java
+++ b/src/main/java/com/adit/backend/global/config/AiConfig.java
@@ -57,7 +57,7 @@ public class AiConfig {
 		// OpenAiAPi 모델 기본 설정 (모델, 최대 토큰수)
 		OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
 			.model(defaultModel)
-			.maxCompletionTokens(maxCompletionToken)
+			// .maxCompletionTokens(maxCompletionToken)
 			.build();
 
 		// ChatModel 생성 (1.0.0-M6)

--- a/src/main/java/com/adit/backend/global/config/AiConfig.java
+++ b/src/main/java/com/adit/backend/global/config/AiConfig.java
@@ -6,16 +6,23 @@ import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
 
 import com.adit.backend.domain.ai.util.LoggingAdvisor;
 
+import io.micrometer.observation.ObservationRegistry;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AiConfig {
 
 	@Value("${spring.ai.openai.api-key}")
@@ -26,6 +33,9 @@ public class AiConfig {
 
 	@Value("${spring.ai.openai.chat.options.max-tokens}")
 	private int maxCompletionToken;
+
+	private final ToolCallingManager toolCallingManager;
+	private final RetryTemplate retryTemplate;
 
 	@Bean
 	ChatMemory chatMemory() {
@@ -39,20 +49,32 @@ public class AiConfig {
 	 */
 	@Bean
 	public ChatClient chatClient() {
-		ChatModel chatModel = new OpenAiChatModel(new OpenAiApi(apiKey),
-			OpenAiChatOptions.builder()
-				.model(defaultModel)
-				.maxCompletionTokens(maxCompletionToken)
-				.build());
+		// OpenAiApi 인스턴스 생성
+		OpenAiApi openAiApi = OpenAiApi.builder()
+			.apiKey(apiKey)
+			.build();
+
+		// OpenAiAPi 모델 기본 설정 (모델, 최대 토큰수)
+		OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
+			.model(defaultModel)
+			.maxCompletionTokens(maxCompletionToken)
+			.build();
+
+		// ChatModel 생성 (1.0.0-M6)
+		ChatModel chatModel = OpenAiChatModel.builder()
+			.openAiApi(openAiApi)
+			.defaultOptions(chatOptions)
+			.toolCallingManager(toolCallingManager)
+			.observationRegistry(ObservationRegistry.create())
+			.retryTemplate(retryTemplate)
+			.build();
 
 		return ChatClient
-			.builder(chatModel)
-			.defaultAdvisors(
+			.builder(chatModel).defaultAdvisors(
 				new MessageChatMemoryAdvisor(chatMemory(),
 					AbstractChatMemoryAdvisor.DEFAULT_CHAT_MEMORY_CONVERSATION_ID, 10),
 				new LoggingAdvisor()
 			)
 			.build();
 	}
-
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] Spring Ai 1.0.0-M6 버전 업그레이드 진행

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)
```java
//OpenAiAPi 정의
OpenAiApi openAiApi = OpenAiApi.builder()
	.apiKey(apiKey)
	.build();

// OpenAiAPi 모델 기본 설정 (모델, 최대 토큰수)
OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
	.model(defaultModel)
	// .maxCompletionTokens(maxCompletionToken)
	.build();

// ChatModel 생성 (1.0.0-M6)
ChatModel chatModel = OpenAiChatModel.builder()
	.openAiApi(openAiApi)
	.defaultOptions(chatOptions)
	.toolCallingManager(toolCallingManager)
	.observationRegistry(ObservationRegistry.create())
	.retryTemplate(retryTemplate)
	.build();
```
- Spring Ai 버전 (1.0.0-M6) 업그레이드로 인하여 기존의 `OpenAiChatModel` 클래스가 deprecated 되었습니다.
- `ToolCallingManager`, `ObservationRegistry` 가 추가되었습니다.
- `builder()`를 이용하여 `AiConfig`를 새롭게 정의하였습니다.
## 📗 참고 자료 (선택)
- [Clarification on OpenAiChatModel Constructor Discrepancy Between Documentation and Code Example](https://github.com/spring-projects/spring-ai/issues/2538)
- close: #114 

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
