### PR TITLE
[Feat] 구글/네이버/카카오 OAuth2 로그인 인증 처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,13 @@ repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }
     maven { url 'https://repo.spring.io/snapshot' }
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+    }
 }
-
 ext {
-    set('springAiVersion', "1.0.0-SNAPSHOT")
+    set('springAiVersion', "1.0.0-M6")
 }
 
 dependencies {

--- a/src/main/java/com/adit/backend/domain/auth/dto/request/KakaoRequest.java
+++ b/src/main/java/com/adit/backend/domain/auth/dto/request/KakaoRequest.java
@@ -1,9 +1,0 @@
-package com.adit.backend.domain.auth.dto.request;
-
-import org.springframework.web.bind.annotation.RequestParam;
-
-public record KakaoRequest() {
-
-	public record AuthDto(@RequestParam("code") String code) {
-	}
-}

--- a/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
@@ -1,0 +1,50 @@
+package com.adit.backend.domain.auth.handler;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.adit.backend.domain.auth.service.GoogleOAuth2UserService;
+import com.adit.backend.domain.auth.service.KakaoOAuth2UserService;
+import com.adit.backend.domain.auth.service.NaverOAuth2UserService;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class DelegatingOAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final Map<String, AuthenticationSuccessHandler> handlerMap;
+
+	public DelegatingOAuth2LoginSuccessHandler(
+		GoogleOAuth2UserService googleHandler,
+		NaverOAuth2UserService naverHandler,
+		KakaoOAuth2UserService kakaoHandler
+	) {
+		this.handlerMap = Map.of(
+			"google", googleHandler,
+			"naver", naverHandler,
+			"kakao", kakaoHandler
+		);
+	}
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+		if (!(authentication instanceof OAuth2AuthenticationToken oAuth2Token)) {
+			throw new IllegalArgumentException("OAuth2AuthenticationToken required");
+		}
+		String registrationId = oAuth2Token.getAuthorizedClientRegistrationId();
+		AuthenticationSuccessHandler delegate = handlerMap.get(registrationId);
+
+		if (delegate == null) {
+			throw new IllegalArgumentException("No handler for provider: " + registrationId);
+		}
+		delegate.onAuthenticationSuccess(request, response, authentication);
+	}
+}

--- a/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
@@ -1,13 +1,17 @@
 package com.adit.backend.domain.auth.handler;
 
+import static com.adit.backend.global.error.GlobalErrorCode.*;
+
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import com.adit.backend.domain.auth.exception.AuthException;
 import com.adit.backend.domain.auth.service.GoogleOAuth2UserService;
 import com.adit.backend.domain.auth.service.KakaoOAuth2UserService;
 import com.adit.backend.domain.auth.service.NaverOAuth2UserService;
@@ -37,10 +41,12 @@ public class DelegatingOAuth2LoginSuccessHandler implements AuthenticationSucces
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 		if (!(authentication instanceof OAuth2AuthenticationToken oAuth2Token)) {
-			throw new IllegalArgumentException("OAuth2AuthenticationToken required");
+			throw new AuthException(INVALID_AUTHENTICATION_TYPE);
 		}
 		String registrationId = oAuth2Token.getAuthorizedClientRegistrationId();
-		AuthenticationSuccessHandler delegate = handlerMap.get(registrationId);
+		AuthenticationSuccessHandler delegate = Optional.ofNullable(handlerMap)
+			.map(v -> v.get(registrationId))
+			.orElseThrow(() -> new AuthException(PROVIDER_NOT_FOUND));
 
 		if (delegate == null) {
 			throw new IllegalArgumentException("No handler for provider: " + registrationId);

--- a/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
@@ -48,9 +48,6 @@ public class DelegatingOAuth2LoginSuccessHandler implements AuthenticationSucces
 			.map(v -> v.get(registrationId))
 			.orElseThrow(() -> new AuthException(PROVIDER_NOT_FOUND));
 
-		if (delegate == null) {
-			throw new IllegalArgumentException("No handler for provider: " + registrationId);
-		}
 		delegate.onAuthenticationSuccess(request, response, authentication);
 	}
 }

--- a/src/main/java/com/adit/backend/domain/auth/service/AbstractOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/AbstractOAuth2UserService.java
@@ -1,0 +1,58 @@
+package com.adit.backend.domain.auth.service;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+import com.adit.backend.domain.user.service.command.UserCommandService;
+import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
+import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
+public abstract class AbstractOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+	protected static final String FRONT_REDIRECT_URI = "http://localhost:5173";
+	protected final JwtTokenProvider jwtTokenProvider;
+	protected final RefreshTokenRepository refreshTokenRepository;
+	protected final UserCommandService userCommandService;
+	@Value("${token.access.header}")
+	protected String accessTokenHeader;
+	@Value("${token.refresh.expiration}")
+	protected String refreshTokenExpiresAt;
+
+	@Value("${token.refresh.cookie.name}")
+	protected String refreshTokenCookieName;
+
+	@Override
+	public abstract void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException;
+
+	public void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response){
+		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+
+		if (cookie.getValue() == null) {
+			cookie.setMaxAge(0);
+			log.debug("[Token] 리프레시 토큰 쿠키 삭제");
+		}
+		cookie.setPath("/");
+		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
+		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		response.addCookie(cookie);
+		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
+	};
+}

--- a/src/main/java/com/adit/backend/domain/auth/service/CustomUserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/CustomUserService.java
@@ -23,6 +23,8 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class CustomUserService extends DefaultOAuth2UserService {
 
+	private static final String NaverRegistrationId = "naver";
+
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
@@ -42,7 +44,7 @@ public class CustomUserService extends DefaultOAuth2UserService {
 		Set<GrantedAuthority> authorities = new HashSet<>(oAuth2User.getAuthorities());
 
 		// ✅ 네이버만 별도 처리
-		if ("naver".equals(registrationId)) {
+		if (NaverRegistrationId.equals(registrationId)) {
 			if (attributes.get("id") == null) {
 				throw new OAuth2AuthenticationException("네이버 응답에 id 없음");
 			}

--- a/src/main/java/com/adit/backend/domain/auth/service/CustomUserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/CustomUserService.java
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class CustomUserService extends DefaultOAuth2UserService {
 
-	private static final String NaverRegistrationId = "naver";
+	private static final String NAVER_REGISTRATION_ID = "naver";
 
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -34,17 +34,17 @@ public class CustomUserService extends DefaultOAuth2UserService {
 
 		OAuth2User oAuth2User;
 		// 기본 정보 먼저 로딩
-		if ("naver".equals(registrationId)) {
+		if (NAVER_REGISTRATION_ID.equals(registrationId)) {
 			oAuth2User = loadNaverUser(userRequest);
 		} else {
 			oAuth2User = super.loadUser(userRequest);
 		}
-		System.out.println(oAuth2User.getAuthorities());
+
 		Map<String, Object> attributes = oAuth2User.getAttributes();
 		Set<GrantedAuthority> authorities = new HashSet<>(oAuth2User.getAuthorities());
 
 		// ✅ 네이버만 별도 처리
-		if (NaverRegistrationId.equals(registrationId)) {
+		if (NAVER_REGISTRATION_ID.equals(registrationId)) {
 			if (attributes.get("id") == null) {
 				throw new OAuth2AuthenticationException("네이버 응답에 id 없음");
 			}

--- a/src/main/java/com/adit/backend/domain/auth/service/CustomUserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/CustomUserService.java
@@ -1,0 +1,109 @@
+package com.adit.backend.domain.auth.service;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class CustomUserService extends DefaultOAuth2UserService {
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+		String accessToken = userRequest.getAccessToken().getTokenValue();
+
+		OAuth2User oAuth2User;
+		// 기본 정보 먼저 로딩
+		if ("naver".equals(registrationId)) {
+			oAuth2User = loadNaverUser(userRequest);
+		} else {
+			oAuth2User = super.loadUser(userRequest);
+		}
+		System.out.println(oAuth2User.getAuthorities());
+		Map<String, Object> attributes = oAuth2User.getAttributes();
+		Set<GrantedAuthority> authorities = new HashSet<>(oAuth2User.getAuthorities());
+
+		// ✅ 네이버만 별도 처리
+		if ("naver".equals(registrationId)) {
+			if (attributes.get("id") == null) {
+				throw new OAuth2AuthenticationException("네이버 응답에 id 없음");
+			}
+
+			return new DefaultOAuth2User(
+				authorities,
+				attributes,  // 이제 평탄화된 attributes 그대로 사용
+				"id"
+			);
+		}
+
+		// ✅ 나머지(Google, Kakao 등)는 그대로 사용
+		return new DefaultOAuth2User(
+			oAuth2User.getAuthorities(),
+			attributes,
+			userRequest.getClientRegistration()
+				.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName()
+		);
+	}
+
+	private OAuth2User loadNaverUser(OAuth2UserRequest userRequest) {
+		OAuth2AccessToken accessToken = userRequest.getAccessToken();
+		String userInfoUri = userRequest.getClientRegistration()
+			.getProviderDetails().getUserInfoEndpoint().getUri();
+
+		// 2. 요청 헤더 생성
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(accessToken.getTokenValue()); // Authorization: Bearer ...
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		// 3. 요청 전송
+		HttpEntity<?> entity = new HttpEntity<>(headers);
+		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<Map> response = restTemplate.exchange(
+			userInfoUri,
+			HttpMethod.GET,
+			entity,
+			Map.class
+		);
+
+		// 4. 응답 파싱
+		Map<String, Object> responseBody = response.getBody();
+		Map<String, Object> userAttributes = (Map<String, Object>)responseBody.get("response");
+
+		if (userAttributes == null || userAttributes.get("id") == null) {
+			throw new OAuth2AuthenticationException("네이버 응답에 id 없음");
+		}
+
+		// 5. 권한 설정
+		Set<GrantedAuthority> authorities = new HashSet<>();
+		authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+		for (String scope : accessToken.getScopes()) {
+			authorities.add(new SimpleGrantedAuthority("SCOPE_" + scope));
+		}
+
+		// 6. OAuth2User 객체 생성
+		return new DefaultOAuth2User(
+			authorities,
+			userAttributes,  // 변경된 변수명
+			"id"
+		);
+	}
+}

--- a/src/main/java/com/adit/backend/domain/auth/service/GoogleOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/GoogleOAuth2UserService.java
@@ -1,14 +1,10 @@
 package com.adit.backend.domain.auth.service;
 
 import java.io.IOException;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Service;
 
 import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
@@ -20,29 +16,17 @@ import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
 import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class GoogleOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+public class GoogleOAuth2UserService extends AbstractOAuth2UserService {
 
-	private final JwtTokenProvider jwtTokenProvider;
-	private final RefreshTokenRepository refreshTokenRepository;
-	private final UserCommandService userCommandService;
-
-	@Value("${token.access.header}")
-	private String accessTokenHeader;
-	@Value("${token.refresh.expiration}")
-	private String refreshTokenExpiresAt;
-
-	@Value("${token.refresh.cookie.name}")
-	private String refreshTokenCookieName;
+	protected GoogleOAuth2UserService(JwtTokenProvider jwtTokenProvider,
+		RefreshTokenRepository refreshTokenRepository,
+		UserCommandService userCommandService) {
+		super(jwtTokenProvider, refreshTokenRepository, userCommandService);
+	}
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -75,24 +59,8 @@ public class GoogleOAuth2UserService extends SimpleUrlAuthenticationSuccessHandl
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		response.sendRedirect("http://localhost:5173");
+		response.sendRedirect(FRONT_REDIRECT_URI);
 
-	}
-
-	private void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
-		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
-		if (cookie.getValue() == null) {
-			cookie.setMaxAge(0);
-			log.debug("[Token] 리프레시 토큰 쿠키 삭제");
-		}
-		cookie.setPath("/");
-		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
-		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
-		cookie.setSecure(true);
-		cookie.setHttpOnly(true);
-		response.addCookie(cookie);
-		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
 	}
 
 }

--- a/src/main/java/com/adit/backend/domain/auth/service/GoogleOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/GoogleOAuth2UserService.java
@@ -1,0 +1,98 @@
+package com.adit.backend.domain.auth.service;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Service;
+
+import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
+import com.adit.backend.domain.user.dto.response.UserResponse;
+import com.adit.backend.domain.user.service.command.UserCommandService;
+import com.adit.backend.global.security.jwt.entity.RefreshToken;
+import com.adit.backend.global.security.jwt.entity.Token;
+import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
+import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoogleOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final UserCommandService userCommandService;
+
+	@Value("${token.access.header}")
+	private String accessTokenHeader;
+	@Value("${token.refresh.expiration}")
+	private String refreshTokenExpiresAt;
+
+	@Value("${token.refresh.cookie.name}")
+	private String refreshTokenCookieName;
+
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws
+		IOException,
+		ServletException {
+
+		//oauth 프로필 추출
+		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+		String name = oAuth2User.getAttribute("name");
+		String profile = oAuth2User.getAttribute("picture");
+		String email = oAuth2User.getAttribute("email");
+		OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.builder()
+			.name(name)
+			.email(email)
+			.profile(profile)
+			.build();
+		UserResponse.InfoDto infoDto = userCommandService.createOrUpdateUser(oAuth2UserInfo);
+
+		//jwt 토큰 생성
+		Token jwtToken = jwtTokenProvider.createToken(infoDto.Id(), infoDto.role());
+		String newAccessToken = jwtToken.getAccessToken();
+		String newRefreshToken = jwtToken.getRefreshToken();
+
+		authentication = jwtTokenProvider.getAuthentication(newAccessToken);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		response.setHeader(accessTokenHeader, "Bearer " + newAccessToken);
+
+		RefreshToken refreshToken = new RefreshToken(infoDto.Id(), newRefreshToken);
+		refreshTokenRepository.save(refreshToken);
+		addRefreshTokenToCookie(newRefreshToken, response);
+
+		response.sendRedirect("http://localhost:5173");
+
+	}
+
+	private void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
+		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+		if (cookie.getValue() == null) {
+			cookie.setMaxAge(0);
+			log.debug("[Token] 리프레시 토큰 쿠키 삭제");
+		}
+		cookie.setPath("/");
+		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
+		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		response.addCookie(cookie);
+		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
+	}
+
+}

--- a/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
@@ -1,14 +1,10 @@
 package com.adit.backend.domain.auth.service;
 
 import java.io.IOException;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Service;
 
 import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
@@ -20,29 +16,17 @@ import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
 import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class KakaoOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+public class KakaoOAuth2UserService extends AbstractOAuth2UserService {
 
-	private final JwtTokenProvider jwtTokenProvider;
-	private final RefreshTokenRepository refreshTokenRepository;
-	private final UserCommandService userCommandService;
-
-	@Value("${token.access.header}")
-	private String accessTokenHeader;
-	@Value("${token.refresh.expiration}")
-	private String refreshTokenExpiresAt;
-
-	@Value("${token.refresh.cookie.name}")
-	private String refreshTokenCookieName;
+	protected KakaoOAuth2UserService(JwtTokenProvider jwtTokenProvider,
+		RefreshTokenRepository refreshTokenRepository,
+		UserCommandService userCommandService) {
+		super(jwtTokenProvider, refreshTokenRepository, userCommandService);
+	}
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -75,24 +59,8 @@ public class KakaoOAuth2UserService extends SimpleUrlAuthenticationSuccessHandle
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		response.sendRedirect("http://localhost:5173");
+		response.sendRedirect(FRONT_REDIRECT_URI);
 
-	}
-
-	private void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
-		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
-		if (cookie.getValue() == null) {
-			cookie.setMaxAge(0);
-			log.debug("[Token] 리프레시 토큰 쿠키 삭제");
-		}
-		cookie.setPath("/");
-		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
-		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
-		cookie.setSecure(true);
-		cookie.setHttpOnly(true);
-		response.addCookie(cookie);
-		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
 	}
 
 }

--- a/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
@@ -1,0 +1,98 @@
+package com.adit.backend.domain.auth.service;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Service;
+
+import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
+import com.adit.backend.domain.user.dto.response.UserResponse;
+import com.adit.backend.domain.user.service.command.UserCommandService;
+import com.adit.backend.global.security.jwt.entity.RefreshToken;
+import com.adit.backend.global.security.jwt.entity.Token;
+import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
+import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final UserCommandService userCommandService;
+
+	@Value("${token.access.header}")
+	private String accessTokenHeader;
+	@Value("${token.refresh.expiration}")
+	private String refreshTokenExpiresAt;
+
+	@Value("${token.refresh.cookie.name}")
+	private String refreshTokenCookieName;
+
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws
+		IOException,
+		ServletException {
+
+		//oauth 프로필 추출
+		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+		String name = oAuth2User.getAttribute("nickname");
+		String profile = oAuth2User.getAttribute("profile_image_url");
+		String email = oAuth2User.getAttribute("email");
+		OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.builder()
+			.name(name)
+			.email(email)
+			.profile(profile)
+			.build();
+		UserResponse.InfoDto infoDto = userCommandService.createOrUpdateUser(oAuth2UserInfo);
+
+		//jwt 토큰 생성
+		Token jwtToken = jwtTokenProvider.createToken(infoDto.Id(), infoDto.role());
+		String newAccessToken = jwtToken.getAccessToken();
+		String newRefreshToken = jwtToken.getRefreshToken();
+
+		authentication = jwtTokenProvider.getAuthentication(newAccessToken);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		response.setHeader(accessTokenHeader, "Bearer " + newAccessToken);
+
+		RefreshToken refreshToken = new RefreshToken(infoDto.Id(), newRefreshToken);
+		refreshTokenRepository.save(refreshToken);
+		addRefreshTokenToCookie(newRefreshToken, response);
+
+		response.sendRedirect("http://localhost:5173");
+
+	}
+
+	private void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
+		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+		if (cookie.getValue() == null) {
+			cookie.setMaxAge(0);
+			log.debug("[Token] 리프레시 토큰 쿠키 삭제");
+		}
+		cookie.setPath("/");
+		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
+		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		response.addCookie(cookie);
+		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
+	}
+
+}

--- a/src/main/java/com/adit/backend/domain/auth/service/NaverOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/NaverOAuth2UserService.java
@@ -1,14 +1,10 @@
 package com.adit.backend.domain.auth.service;
 
 import java.io.IOException;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Service;
 
 import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
@@ -20,29 +16,17 @@ import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
 import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class NaverOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+public class NaverOAuth2UserService extends AbstractOAuth2UserService {
 
-	private final JwtTokenProvider jwtTokenProvider;
-	private final RefreshTokenRepository refreshTokenRepository;
-	private final UserCommandService userCommandService;
-
-	@Value("${token.access.header}")
-	private String accessTokenHeader;
-	@Value("${token.refresh.expiration}")
-	private String refreshTokenExpiresAt;
-
-	@Value("${token.refresh.cookie.name}")
-	private String refreshTokenCookieName;
+	protected NaverOAuth2UserService(JwtTokenProvider jwtTokenProvider,
+		RefreshTokenRepository refreshTokenRepository,
+		UserCommandService userCommandService) {
+		super(jwtTokenProvider, refreshTokenRepository, userCommandService);
+	}
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -75,24 +59,8 @@ public class NaverOAuth2UserService extends SimpleUrlAuthenticationSuccessHandle
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		response.sendRedirect("http://localhost:5173");
+		response.sendRedirect(FRONT_REDIRECT_URI);
 
-	}
-
-	private void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
-		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
-		if (cookie.getValue() == null) {
-			cookie.setMaxAge(0);
-			log.debug("[Token] 리프레시 토큰 쿠키 삭제");
-		}
-		cookie.setPath("/");
-		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
-		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
-		cookie.setSecure(true);
-		cookie.setHttpOnly(true);
-		response.addCookie(cookie);
-		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
 	}
 
 }

--- a/src/main/java/com/adit/backend/domain/auth/service/NaverOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/NaverOAuth2UserService.java
@@ -1,0 +1,98 @@
+package com.adit.backend.domain.auth.service;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Service;
+
+import com.adit.backend.domain.auth.dto.OAuth2UserInfo;
+import com.adit.backend.domain.user.dto.response.UserResponse;
+import com.adit.backend.domain.user.service.command.UserCommandService;
+import com.adit.backend.global.security.jwt.entity.RefreshToken;
+import com.adit.backend.global.security.jwt.entity.Token;
+import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
+import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class NaverOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final UserCommandService userCommandService;
+
+	@Value("${token.access.header}")
+	private String accessTokenHeader;
+	@Value("${token.refresh.expiration}")
+	private String refreshTokenExpiresAt;
+
+	@Value("${token.refresh.cookie.name}")
+	private String refreshTokenCookieName;
+
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws
+		IOException,
+		ServletException {
+
+		//oauth 프로필 추출
+		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+		String name = oAuth2User.getAttribute("name");
+		String profile = oAuth2User.getAttribute("profile_image");
+		String email = oAuth2User.getAttribute("email");
+		OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.builder()
+			.name(name)
+			.email(email)
+			.profile(profile)
+			.build();
+		UserResponse.InfoDto infoDto = userCommandService.createOrUpdateUser(oAuth2UserInfo);
+
+		//jwt 토큰 생성
+		Token jwtToken = jwtTokenProvider.createToken(infoDto.Id(), infoDto.role());
+		String newAccessToken = jwtToken.getAccessToken();
+		String newRefreshToken = jwtToken.getRefreshToken();
+
+		authentication = jwtTokenProvider.getAuthentication(newAccessToken);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		response.setHeader(accessTokenHeader, "Bearer " + newAccessToken);
+
+		RefreshToken refreshToken = new RefreshToken(infoDto.Id(), newRefreshToken);
+		refreshTokenRepository.save(refreshToken);
+		addRefreshTokenToCookie(newRefreshToken, response);
+
+		response.sendRedirect("http://localhost:5173");
+
+	}
+
+	private void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
+		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+		if (cookie.getValue() == null) {
+			cookie.setMaxAge(0);
+			log.debug("[Token] 리프레시 토큰 쿠키 삭제");
+		}
+		cookie.setPath("/");
+		ZonedDateTime seoulTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+		ZonedDateTime expirationTime = seoulTime.plusSeconds(Long.parseLong(refreshTokenExpiresAt));
+		cookie.setMaxAge((int)(expirationTime.toEpochSecond() - seoulTime.toEpochSecond()));
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		response.addCookie(cookie);
+		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
+	}
+
+}

--- a/src/main/java/com/adit/backend/global/config/AiConfig.java
+++ b/src/main/java/com/adit/backend/global/config/AiConfig.java
@@ -6,16 +6,23 @@ import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
 
 import com.adit.backend.domain.ai.util.LoggingAdvisor;
 
+import io.micrometer.observation.ObservationRegistry;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AiConfig {
 
 	@Value("${spring.ai.openai.api-key}")
@@ -26,6 +33,9 @@ public class AiConfig {
 
 	@Value("${spring.ai.openai.chat.options.max-tokens}")
 	private int maxCompletionToken;
+
+	private final ToolCallingManager toolCallingManager;
+	private final RetryTemplate retryTemplate;
 
 	@Bean
 	ChatMemory chatMemory() {
@@ -39,20 +49,32 @@ public class AiConfig {
 	 */
 	@Bean
 	public ChatClient chatClient() {
-		ChatModel chatModel = new OpenAiChatModel(new OpenAiApi(apiKey),
-			OpenAiChatOptions.builder()
-				.model(defaultModel)
-				.maxCompletionTokens(maxCompletionToken)
-				.build());
+		// OpenAiApi 인스턴스 생성
+		OpenAiApi openAiApi = OpenAiApi.builder()
+			.apiKey(apiKey)
+			.build();
+
+		// OpenAiAPi 모델 기본 설정 (모델, 최대 토큰수)
+		OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
+			.model(defaultModel)
+			// .maxCompletionTokens(maxCompletionToken)
+			.build();
+
+		// ChatModel 생성 (1.0.0-M6)
+		ChatModel chatModel = OpenAiChatModel.builder()
+			.openAiApi(openAiApi)
+			.defaultOptions(chatOptions)
+			.toolCallingManager(toolCallingManager)
+			.observationRegistry(ObservationRegistry.create())
+			.retryTemplate(retryTemplate)
+			.build();
 
 		return ChatClient
-			.builder(chatModel)
-			.defaultAdvisors(
+			.builder(chatModel).defaultAdvisors(
 				new MessageChatMemoryAdvisor(chatMemory(),
 					AbstractChatMemoryAdvisor.DEFAULT_CHAT_MEMORY_CONVERSATION_ID, 10),
 				new LoggingAdvisor()
 			)
 			.build();
 	}
-
 }

--- a/src/main/java/com/adit/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/adit/backend/global/config/SecurityConfig.java
@@ -18,6 +18,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.CorsFilter;
 
+import com.adit.backend.domain.auth.handler.DelegatingOAuth2LoginSuccessHandler;
+import com.adit.backend.domain.auth.service.CustomUserService;
 import com.adit.backend.global.security.jwt.filter.JwtAuthorizationFilter;
 import com.adit.backend.global.security.jwt.filter.TokenExceptionFilter;
 import com.adit.backend.global.security.jwt.handler.CustomAccessDeniedHandler;
@@ -40,7 +42,6 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
 	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
-
 	private static final String[] WHITE_LIST = {
 		"/login/**",
 		"/api/ai/**",
@@ -49,12 +50,15 @@ public class SecurityConfig {
 		"/webjars/**",
 		"/api/scraper/**",
 		"/oauth2/**",
+		"/naver/userinfo"
 	};
+	private final DelegatingOAuth2LoginSuccessHandler delegatingOAuth2LoginSuccessHandler;
 	private final CorsFilter corsFilter;
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 	private final OAuth2FailureHandler oAuth2FailureHandler;
 	private final JwtAuthorizationFilter jwtAuthorizationFilter;
+	private final CustomUserService customUserService;
 	@Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
 	String frontRedirectUrl;
 
@@ -118,7 +122,12 @@ public class SecurityConfig {
 			)
 
 			// OAuth2 로그인 설정
-			.oauth2Login(AbstractHttpConfigurer::disable
+			.oauth2Login(oauth2 -> oauth2
+				.userInfoEndpoint(userInfo -> userInfo
+					.userService(customUserService) // ✅ 사용자 정보 로딩 시
+				)
+				.successHandler(delegatingOAuth2LoginSuccessHandler) // ✅ 로그인 성공 후
+
 				// .authorizationEndpoint(authEndpoint -> authEndpoint
 				// 	.baseUri("/oauth2/authorization")
 				// 	.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository))

--- a/src/main/java/com/adit/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/adit/backend/global/config/SecurityConfig.java
@@ -49,8 +49,7 @@ public class SecurityConfig {
 		"/api/auth/**",
 		"/webjars/**",
 		"/api/scraper/**",
-		"/oauth2/**",
-		"/naver/userinfo"
+		"/oauth2/**"
 	};
 	private final DelegatingOAuth2LoginSuccessHandler delegatingOAuth2LoginSuccessHandler;
 	private final CorsFilter corsFilter;

--- a/src/main/java/com/adit/backend/global/error/GlobalErrorCode.java
+++ b/src/main/java/com/adit/backend/global/error/GlobalErrorCode.java
@@ -53,6 +53,8 @@ public enum GlobalErrorCode implements ErrorCode {
 	KAKAO_LOGIN_FAILED(UNAUTHORIZED, "AUTH-013", "카카오 로그인에 실패했습니다."),
 	REFRESH_TOKEN_BLACKLISTED(UNAUTHORIZED, "AUTH-014", "블랙리스트에 등록된 리프레시 토큰입니다."),
 	REFRESH_TOKEN_MISMATCH(UNAUTHORIZED, "AUTH-015", "리프레시 토큰이 일치하지 않습니다."),
+	INVALID_AUTHENTICATION_TYPE(UNAUTHORIZED, "AUTH-016", "Authentication 객체 타입이 올바르지 않습니다."),
+	PROVIDER_NOT_FOUND(NOT_FOUND, "AUTH-017", "provider 를 찾지 못했습니다."),
 
 	/********************************** User Domain **********************************/
 	USER_NOT_FOUND(NOT_FOUND, "USR-001", "사용자를 찾지 못했습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,12 +26,12 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: openid, email, profile
-            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
             authorization-grant-type: authorization_code
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            redirect-uri: ${NAVER_REDIRECT_URI}
             authorization-grant-type: authorization_code
             scope:
               - name

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,23 @@ spring:
               - account_email
               - profile_image
             client-name: kakao
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: openid, email, profile
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            authorization-grant-type: authorization_code
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+              - profile_image
+
+            client-name: naver
         # kakao provider 설정
         provider:
           kakao:
@@ -29,7 +46,16 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id # 유저 정보 조회 시 반환되는 최상위 필드명으로 해야 한다.
-
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://openidconnect.googleapis.com/v1/userinfo
+            user-name-attribute: sub
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: id
   ai:
     openai:
       api-key: ${SPRING_AI_OPENAI_API_KEY}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 기존에는 프론트엔드에서 인가 코드를 받아 백엔드로 전달해 소셜 로그인 처리를 진행했지만, 보안성과 흐름 통일을 위해 OAuth2 인증 후 후처리 과정을 백엔드에서 전부 수행하도록 리팩토링

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
