### PR TITLE
[Refactor] 카카오 소셜 로그인 시, 프로필 추출 로직 수정

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -28,6 +28,7 @@ jobs:
           echo "SERVER_DB_PASSWORD=${{ secrets.SERVER_DB_PASSWORD }}" >> .env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
           echo "KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}" >> .env
+          echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
           echo "SPRING_AI_OPENAI_API_KEY=${{ secrets.SPRING_AI_OPENAI_API_KEY }}" >> .env
           echo "JWT_KEY=${{ secrets.JWT_KEY }}" >> .env
           echo "JWT_ACCESS_TOKEN_EXPIRATION=${{ secrets.JWT_ACCESS_TOKEN_EXPIRATION }}" >> .env

--- a/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.adit.backend.domain.auth.service;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,13 +37,17 @@ public class KakaoOAuth2UserService extends AbstractOAuth2UserService {
 
 		//oauth 프로필 추출
 		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
-		String name = oAuth2User.getAttribute("nickname");
-		String profile = oAuth2User.getAttribute("profile_image_url");
-		String email = oAuth2User.getAttribute("email");
+		Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+		Map<String, Object> profile = (Map<String, Object>)kakaoAccount.get("profile");
+
+		String email = (String)kakaoAccount.get("email");
+		String name = (String)profile.get("nickname");
+		String profileImage = (String)profile.get("profile_image_url");
+
 		OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.builder()
 			.name(name)
 			.email(email)
-			.profile(profile)
+			.profile(profileImage)
 			.build();
 		UserResponse.InfoDto infoDto = userCommandService.createOrUpdateUser(oAuth2UserInfo);
 

--- a/src/main/java/com/adit/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/adit/backend/global/config/SecurityConfig.java
@@ -105,6 +105,7 @@ public class SecurityConfig {
 			.formLogin(AbstractHttpConfigurer::disable)
 			// 로그아웃 기능 비활성화
 			.logout(AbstractHttpConfigurer::disable)
+
 			// X-Frame-Options 헤더 설정 비활성화
 			.headers(c -> c.frameOptions(
 				HeadersConfigurer.FrameOptionsConfig::disable).disable())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: ${redirect.url}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
             client-authentication-method: client_secret_post # kakao는 인증 토큰 발급 요청 메서드가 post이다. (최근 버전에는 작성 방법이 이렇게 바뀌었다.)
             authorization-grant-type: authorization_code
             scope: # kakao 개인 정보 동의 항목 설정의 ID 값


### PR DESCRIPTION
## 💡 작업 내용

- [x] 카카오 소셜 로그인 시, 기존 방식은 프로필 추출에 제한이 있어, 정상적으로 추출할 수 있도록 수정

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
