### PR TITLE
[Fix] Blue/Green Docker 배포 최적화 - CPU 과부하 문제 해결

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -108,21 +108,26 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd /home/ubuntu
-      
-            # 1) blue, green 컨테이너 중 실제로 존재하는 ID만 조회
-            CONTAINERS=$(sudo docker ps -aq --filter "name=^blue$" --filter "name=^green$")
-      
-            # 2) 컨테이너가 있을 때만 강제 삭제
+            
+            # 1) 대상 컨테이너 식별 (graceful 종료를 위한 준비)
+            CONTAINERS=$(sudo docker ps -aq --filter "name=^${{ env.TARGET_UPSTREAM }}$")
+            
+            # 2) 컨테이너가 있을 때만 graceful 종료 
             if [ -n "$CONTAINERS" ]; then
-              echo "🗑️ 삭제 중인 컨테이너: $CONTAINERS"
-              sudo docker rm -f $CONTAINERS
+              echo "🛑 ${{ env.TARGET_UPSTREAM }} 컨테이너 정지 중: $CONTAINERS"
+              # 강제 종료 대신 30초 timeout으로 정상 종료 (SIGTERM 신호)
+              sudo docker stop --time=30 $CONTAINERS
+              
+              # 정지된 컨테이너만 제거
+              sudo docker rm $CONTAINERS
+              
+              # 잠시 대기하여 시스템 자원이 안정화되도록 함
+              sleep 5
             else
-              echo "ℹ️ 삭제할 blue/green 컨테이너가 존재하지 않습니다."
+              echo "ℹ️ 정지할 ${{ env.TARGET_UPSTREAM }} 컨테이너가 존재하지 않습니다."
             fi
-      
-            # 3) 사용하지 않는 이미지 정리
-            sudo docker image prune -f
-
+            
+            # 이미지 정리는 배포 완료 후 별도 단계에서 수행
 
       - name: 새 대상 컨테이너 배포
         uses: appleboy/ssh-action@v0.1.10
@@ -133,7 +138,21 @@ jobs:
           script: |
             cd /home/ubuntu
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/live_server:latest
+            
+            # docker-compose 파일에 리소스 제한이 없다면, 이를 설정하는 명령어 실행
+            # CPU 및 메모리 제한 설정 (기존 docker-compose 파일이 덮어씌워지지 않도록 백업)
+            if ! grep -q "cpu_" docker-compose-${{ env.TARGET_UPSTREAM }}.yml; then
+              cp docker-compose-${{ env.TARGET_UPSTREAM }}.yml docker-compose-${{ env.TARGET_UPSTREAM }}.yml.bak
+              
+              # 컨테이너 리소스 제한 설정 추가
+              sed -i '/restart: always/a\    deploy:\n      resources:\n        limits:\n          cpus: "1.0"\n          memory: 1G\n        reservations:\n          memory: 512M' docker-compose-${{ env.TARGET_UPSTREAM }}.yml
+            fi
+            
+            # 컨테이너 시작 (detached 모드)
             sudo docker-compose -f docker-compose-${{ env.TARGET_UPSTREAM }}.yml up -d
+            
+            # 컨테이너 시작 후 5초 대기하여 안정화
+            sleep 5
 
       - name: 새 컨테이너 헬스 체크
         run: |
@@ -182,7 +201,28 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd /home/ubuntu
-            sudo docker-compose -f docker-compose-${{ env.CURRENT_UPSTREAM }}.yml down || true
+            
+            # 이전 환경의 컨테이너 확인
+            if [ -f "docker-compose-${{ env.CURRENT_UPSTREAM }}.yml" ]; then
+              # Graceful 종료 (30초 timeout)
+              sudo docker-compose -f docker-compose-${{ env.CURRENT_UPSTREAM }}.yml stop --timeout 30
+              # 정지된 컨테이너 제거
+              sudo docker-compose -f docker-compose-${{ env.CURRENT_UPSTREAM }}.yml rm -f
+            fi
+            
+      - name: 시스템 정리 (이미지 및 볼륨)
+        if: ${{ success() }}
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            sudo docker image prune -f
+            
+            sudo docker volume prune -f
+            
+            # sudo docker system prune -af --volumes
 
       - name: Blue/Green 배포 완료 알림
         run: |


### PR DESCRIPTION
## 💡 작업 내용

- [x] Blue/Green Docker 배포 과정에서 발생하는 EC2 인스턴스 CPU 사용률 100% 급증 문제를 해결하기 위한 워크플로우 개선

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

### 문제점 파악
1. **강제적 컨테이너 종료**: `docker rm -f` 명령어를 사용하여 컨테이너를 강제로 종료하면 정상적인 종료 절차 없이 즉시 중단되어 시스템 리소스 스파이크 발생
2. **즉각적인 교체 작업**: 기존 컨테이너 제거 후 시스템 안정화 시간 없이 즉시 새 컨테이너 시작
3. **배포 중 이미지 정리**: 배포 과정에서 `docker image prune -f`를 실행하여 시스템에 추가 부하 발생
4. **메모리 누수 가능성**: Docker가 강제 컨테이너 제거와 함께 메모리 누수 문제 발생 가능성
> 기존 리소스 낭비 방지를 위해 채택한 graceful shutdown을 제대로 활용하지 않는 배포 방식이 주된 문제 (#84)

### 개선 사항
1. 정상적인 컨테이너 종료 구현 (`docker rm -f` 대신 `docker stop --time=30` 사용) 
2. 정리 프로세스 최적화 (이미지 정리 작업을 중요 배포 경로에서 분리하여 배포 성공 후에 실행)
3. 이전 컨테이너 처리 개선 (리소스 스파이크를 방지하기 위한 제어된 종료 타임아웃 구현)

- 기존 배포 방식보다 시간은 더 소요되지만 서버 안정화를 위해 필요한 과정이었다고 생각합니다.

## 📗 참고 자료 (선택)
close #133 

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
