### PR TITLE
[Fix] Redis에 의한 소셜 로그인 작동 중단 해결 완료

### DIFF
--- a/src/main/java/com/adit/backend/domain/auth/service/AbstractOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/AbstractOAuth2UserService.java
@@ -3,6 +3,7 @@ package com.adit.backend.domain.auth.service;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Slf4j
 public abstract class AbstractOAuth2UserService extends SimpleUrlAuthenticationSuccessHandler {
+	private static final String FRONT_PORT = "5173";
 	protected static final String FRONT_REDIRECT_URI = "http://localhost:5173";
 	protected final JwtTokenProvider jwtTokenProvider;
 	protected final RefreshTokenRepository refreshTokenRepository;
@@ -31,15 +33,16 @@ public abstract class AbstractOAuth2UserService extends SimpleUrlAuthenticationS
 	protected String accessTokenHeader;
 	@Value("${token.refresh.expiration}")
 	protected String refreshTokenExpiresAt;
-
 	@Value("${token.refresh.cookie.name}")
 	protected String refreshTokenCookieName;
+	@Value("${base-url}")
+	protected String baseUrl;
 
 	@Override
 	public abstract void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException;
 
-	public void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response){
+	public void addRefreshTokenToCookie(String refreshToken, HttpServletResponse response) {
 		Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
 
 		if (cookie.getValue() == null) {
@@ -54,5 +57,17 @@ public abstract class AbstractOAuth2UserService extends SimpleUrlAuthenticationS
 		cookie.setHttpOnly(true);
 		response.addCookie(cookie);
 		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
-	};
+	}
+
+	protected String determineRedirectUrl(HttpServletRequest request) {
+		String sourceUrl = Optional
+			.ofNullable(request.getHeader("Referer"))
+			.orElse(request.getHeader("Origin"));
+
+		log.debug("[OAuth2] Source URL: {}", sourceUrl);
+
+		return (sourceUrl != null && sourceUrl.contains(FRONT_PORT))
+			? FRONT_REDIRECT_URI
+			: baseUrl;
+	}
 }

--- a/src/main/java/com/adit/backend/domain/auth/service/GoogleOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/GoogleOAuth2UserService.java
@@ -15,10 +15,11 @@ import com.adit.backend.global.security.jwt.entity.Token;
 import com.adit.backend.global.security.jwt.repository.RefreshTokenRepository;
 import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class GoogleOAuth2UserService extends AbstractOAuth2UserService {
 
@@ -31,8 +32,7 @@ public class GoogleOAuth2UserService extends AbstractOAuth2UserService {
 	@Override
 	public void onAuthenticationSuccess(
 		HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws
-		IOException,
-		ServletException {
+		IOException {
 
 		//oauth 프로필 추출
 		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
@@ -59,8 +59,9 @@ public class GoogleOAuth2UserService extends AbstractOAuth2UserService {
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		response.sendRedirect(FRONT_REDIRECT_URI);
-
+		String redirectUrl = determineRedirectUrl(request);
+		log.debug("[Google OAuth2] 리다이렉션 URL: {}", redirectUrl);
+		response.sendRedirect(redirectUrl);
 	}
-
 }
+

--- a/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/KakaoOAuth2UserService.java
@@ -19,7 +19,9 @@ import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class KakaoOAuth2UserService extends AbstractOAuth2UserService {
 
@@ -64,8 +66,8 @@ public class KakaoOAuth2UserService extends AbstractOAuth2UserService {
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		response.sendRedirect(FRONT_REDIRECT_URI);
-
+		String redirectUrl = determineRedirectUrl(request);
+		log.debug("[Kakao OAuth2] 리다이렉션 URL: {}", redirectUrl);
+		response.sendRedirect(redirectUrl);
 	}
-
 }

--- a/src/main/java/com/adit/backend/domain/auth/service/NaverOAuth2UserService.java
+++ b/src/main/java/com/adit/backend/domain/auth/service/NaverOAuth2UserService.java
@@ -18,7 +18,9 @@ import com.adit.backend.global.security.jwt.util.JwtTokenProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class NaverOAuth2UserService extends AbstractOAuth2UserService {
 
@@ -59,8 +61,8 @@ public class NaverOAuth2UserService extends AbstractOAuth2UserService {
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		response.sendRedirect(FRONT_REDIRECT_URI);
-
+		String redirectUrl = determineRedirectUrl(request);
+		log.debug("[Naver OAuth2] 리다이렉션 URL: {}", redirectUrl);
+		response.sendRedirect(redirectUrl);
 	}
-
 }

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -33,6 +33,9 @@ spring:
     vectorstore:
       chroma:
         client:
+          host: http://localhost
+
+base-url: ${SERVER_BASE_URL}
 
 redirect:
   kakaoUrl: ${SERVER_BASE_URL}/login/oauth2/code/kakao

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -29,6 +29,14 @@ spring:
         default_batch_fetch_size: 1000
   lifecycle:
     timeout-per-shutdown-phase: 30s
+  ai:
+    vectorstore:
+      chroma:
+        client:
+          host: http://localhost
+
+base-url: ${SERVER_BASE_URL}
+
 redirect:
   kakaoUrl: ${SERVER_BASE_URL}/login/oauth2/code/kakao
   googleUrl: ${SERVER_BASE_URL}/login/oauth2/code/google

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,6 +29,8 @@ springdoc:
   swagger-ui:
     path: /
 
+base-url: ${LOCAL_BASE_URL}
+
 redirect:
   kakaoUrl: ${LOCAL_BASE_URL}/login/oauth2/code/kakao
   googleUrl: ${LOCAL_BASE_URL}/login/oauth2/code/google

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,7 +71,7 @@ spring:
           max-tokens: ${SPRING_AI_MAX_TOKENS}
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
   servlet:


### PR DESCRIPTION
## 💡 작업 내용

- [x] Redis 호스트 설정값 `localhost`로 변경
- [x] 서버 환경에서 API 테스트를 위한 소셜 로그인 리다이렉션 URI 구분 

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)
- 호스트 값이 `redis`로 되어있었습니다 🥲
- 서버 환경에 배포시 토큰 발급을 위한 리다이렉션 지정 문제가 발생하여 프론트와 백엔드 파트 요청 간 리다이렉션을 달리하는 로직을 추가하였습니다. 
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
