### PR TITLE
[Fix] HttpCookieOAuth2AuthorizationRequestRepository 을 사용하여 쿠키 기반 저장 방식으로 변경

### DIFF
--- a/src/main/java/com/adit/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/adit/backend/global/config/SecurityConfig.java
@@ -10,7 +10,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsUtils;
@@ -23,6 +25,7 @@ import com.adit.backend.global.security.jwt.filter.TokenExceptionFilter;
 import com.adit.backend.global.security.jwt.handler.CustomAccessDeniedHandler;
 import com.adit.backend.global.security.jwt.handler.CustomAuthenticationEntryPoint;
 import com.adit.backend.global.security.oauth.handler.OAuth2FailureHandler;
+import com.adit.backend.global.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -75,6 +78,11 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+		return new HttpCookieOAuth2AuthorizationRequestRepository();
+	}
+
+	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		AuthenticationManagerBuilder sharedObject = http.getSharedObject(AuthenticationManagerBuilder.class);
 		AuthenticationManager authenticationManager = sharedObject.build();
@@ -110,6 +118,8 @@ public class SecurityConfig {
 
 			// OAuth2 로그인 설정
 			.oauth2Login(oauth2 -> oauth2
+				.authorizationEndpoint(authorization -> authorization
+					.authorizationRequestRepository(authorizationRequestRepository()))
 				.userInfoEndpoint(userInfo -> userInfo
 					.userService(customUserService) // ✅ 사용자 정보 로딩 시
 				)


### PR DESCRIPTION
## 💡 작업 내용

- [x] 세션 없이 인증 요청 정보를 유지하기 위해 HttpCookieOAuth2AuthorizationRequestRepository 사용
- [x] SessionCreationPolicy.STATELESS 환경에서도 Oauth2 로그인 흐름 정상 작동 가능 

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
