### PR TITLE
[Fix] HttpCookieOAuth2AuthorizationRequestRepository 을 사용하여 쿠키 기반 저장 방식으로 변경

### DIFF
--- a/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/adit/backend/domain/auth/handler/DelegatingOAuth2LoginSuccessHandler.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import com.adit.backend.domain.auth.exception.AuthException;
+import com.adit.backend.domain.auth.repository.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.adit.backend.domain.auth.service.GoogleOAuth2UserService;
 import com.adit.backend.domain.auth.service.KakaoOAuth2UserService;
 import com.adit.backend.domain.auth.service.NaverOAuth2UserService;
@@ -24,17 +25,20 @@ import jakarta.servlet.http.HttpServletResponse;
 public class DelegatingOAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
 	private final Map<String, AuthenticationSuccessHandler> handlerMap;
+	private final HttpCookieOAuth2AuthorizationRequestRepository authRequestRepository;
 
 	public DelegatingOAuth2LoginSuccessHandler(
 		GoogleOAuth2UserService googleHandler,
 		NaverOAuth2UserService naverHandler,
-		KakaoOAuth2UserService kakaoHandler
+		KakaoOAuth2UserService kakaoHandler,
+		HttpCookieOAuth2AuthorizationRequestRepository authRequestRepository
 	) {
 		this.handlerMap = Map.of(
 			"google", googleHandler,
 			"naver", naverHandler,
 			"kakao", kakaoHandler
 		);
+		this.authRequestRepository = authRequestRepository;
 	}
 
 	@Override
@@ -43,6 +47,10 @@ public class DelegatingOAuth2LoginSuccessHandler implements AuthenticationSucces
 		if (!(authentication instanceof OAuth2AuthenticationToken oAuth2Token)) {
 			throw new AuthException(INVALID_AUTHENTICATION_TYPE);
 		}
+
+
+		authRequestRepository.removeAuthorizationRequestCookies(request, response);
+
 		String registrationId = oAuth2Token.getAuthorizedClientRegistrationId();
 		AuthenticationSuccessHandler delegate = Optional.ofNullable(handlerMap)
 			.map(v -> v.get(registrationId))

--- a/src/main/java/com/adit/backend/domain/auth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/adit/backend/domain/auth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,55 @@
+package com.adit.backend.domain.auth.repository;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import com.adit.backend.domain.auth.util.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+	public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+	private static final int cookieExpireSeconds = 180;
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		OAuth2AuthorizationRequest oAuth2AuthorizationRequest =  CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+			.map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+			.orElse(null);
+		return oAuth2AuthorizationRequest;
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+		HttpServletResponse response) {
+		return this.loadAuthorizationRequest(request);
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			removeAuthorizationRequest(request, response);
+			return;
+		}
+
+		CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+		if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+			CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+		}
+	}
+
+
+
+	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+		CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+	}
+
+}

--- a/src/main/java/com/adit/backend/domain/auth/util/CookieUtils.java
+++ b/src/main/java/com/adit/backend/domain/auth/util/CookieUtils.java
@@ -1,0 +1,56 @@
+package com.adit.backend.domain.auth.util;
+
+import java.util.Base64;
+import java.util.Optional;
+
+import org.springframework.util.SerializationUtils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtils {
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					cookie.setValue("");
+					cookie.setPath("/");
+					cookie.setMaxAge(0);
+					response.addCookie(cookie);
+				}
+			}
+		}
+	}
+
+	public static String serialize(Object object) {
+		return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+	}
+
+}

--- a/src/main/java/com/adit/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/adit/backend/global/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+	public AuthorizationRequestRepository<OAuth2AuthorizationRequest> cookieOAuth2AuthorizationRequestRepository() {
 		return new HttpCookieOAuth2AuthorizationRequestRepository();
 	}
 
@@ -119,7 +119,7 @@ public class SecurityConfig {
 			// OAuth2 로그인 설정
 			.oauth2Login(oauth2 -> oauth2
 				.authorizationEndpoint(authorization -> authorization
-					.authorizationRequestRepository(authorizationRequestRepository()))
+					.authorizationRequestRepository(cookieOAuth2AuthorizationRequestRepository()))
 				.userInfoEndpoint(userInfo -> userInfo
 					.userService(customUserService) // ✅ 사용자 정보 로딩 시
 				)


### PR DESCRIPTION
## 💡 작업 내용

- [x] HttpCookieOAuth2AuthorizationRequestRepository 클래스를 커스터마이징 하여 소셜 로그인 요청 정보가 쿠키에 담기게 하여, 서버 환경에서도 로그인 처리가 가능하도록 개선

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
