### PR TITLE
[Feat] SonarCloud를 이용한 정적 분석 도입

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: SonarQube
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin' # Alternative distribution options are available
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
     id "org.sonarqube" version "6.2.0.5505"
 }
 
+apply from: 'jacoco.gradle'
+
 group = 'com.adit'
 version = '0.0.1-SNAPSHOT'
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,18 +108,3 @@ tasks.register('buildDocker', Jar) {
 clean.doLast {
     file(querydslDir).deleteDir()
 }
-
-sonar {
-    properties {
-        property "sonar.projectKey", "cotato_odit"
-        property "sonar.organization", "cotato"
-        property "sonar.host.url", "https://sonarcloud.io"
-        property 'sonar.sources', 'src'
-        property 'sonar.language', 'java'
-        property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
-        property 'sonar.test.inclusions', '**/*Test.java'
-        property 'sonar.java.coveragePlugin', 'jacoco'
-        property 'sonar.coverage.jacoco.xmlReportPaths', jacocoDir.get().file("jacoco/index.xml").asFile
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "jacoco"
     id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
-    id "org.sonarqube" version '3.5.0.2730'
+    id "org.sonarqube" version "6.2.0.5505"
 }
 
 group = 'com.adit'
@@ -107,4 +107,19 @@ tasks.register('buildDocker', Jar) {
 
 clean.doLast {
     file(querydslDir).deleteDir()
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "cotato_odit"
+        property "sonar.organization", "cotato"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property 'sonar.sources', 'src'
+        property 'sonar.language', 'java'
+        property 'sonar.sourceEncoding', 'UTF-8'
+        property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+        property 'sonar.test.inclusions', '**/*Test.java'
+        property 'sonar.java.coveragePlugin', 'jacoco'
+        property 'sonar.coverage.jacoco.xmlReportPaths', jacocoDir.get().file("jacoco/index.xml").asFile
+    }
 }

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,30 +1,29 @@
+def jacocoExcludePatterns = [
+        "**/*Application*",
+        "**/*Config*",
+        "**/*Exception*",
+        "**/*Request*",
+        "**/*Response*",
+        "**/*Dto*",
+        "**/*Filter*",
+        "**/*Entity*",
+        "**/test/**",
+        "**/resources/**"
+]
+
+def QDomains = []
+for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+    QDomains.add(qPattern + '*')
+}
+
+def jacocoDir = layout.buildDirectory.dir("reports/")
+
 subprojects {
     // ...
     apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'jacoco'
-
-    def jacocoExcludePatterns = [
-            "**/*Application*",
-            "**/*Config*",
-            "**/*Exception*",
-            "**/*Request*",
-            "**/*Response*",
-            "**/*Dto*",
-            "**/*Filter*",
-            "**/*Entity*",
-            "**/test/**",
-            "**/resources/**"
-    ]
-
-    def QDomains = []
-    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
-        QDomains.add(qPattern + '*')
-    }
-
-    def jacocoDir = layout.buildDirectory.dir("reports/")
-
 
     configurations {
         compileOnly {
@@ -89,7 +88,19 @@ subprojects {
         }
         finalizedBy jacocoTestCoverageVerification
     }
+}
 
-
-    // ...
+sonar {
+    properties {
+        property "sonar.projectKey", "cotato_odit"
+        property "sonar.organization", "cotato"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property 'sonar.sources', 'src'
+        property 'sonar.language', 'java'
+        property 'sonar.sourceEncoding', 'UTF-8'
+        property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+        property 'sonar.test.inclusions', '**/*Test.java'
+        property 'sonar.java.coveragePlugin', 'jacoco'
+        property 'sonar.coverage.jacoco.xmlReportPaths', jacocoDir.get().file("jacoco/index.xml").asFile
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] Jacoco 코드 커버리지 도입
- [x] SonarCloud를 이용한 정적 분석 도입

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)
- 리팩토링과 테스트 코드 작성이 주된 작업이 될 것 같습니다. 이를 보조하기 위해서 테스트 코드가 부족한 부분을 확인하고, 코드 품질을 모니터링하기 위해서 Jacoco, SonarCloud 도입 진행하였습니다. 현재 커버리지 목표치는 80%로 점차 높여갈 생각입니다. 


## 📗 참고 자료 (선택)
close #113 
- [Sonar Cloud Docs](https://docs.sonarsource.com/sonarqube-cloud/)
> ![image](https://github.com/user-attachments/assets/64c1ee71-ee83-4efc-ac56-f2cbd915be67)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?
