### PR TITLE
[Refactor] 이벤트 등록 API 수정

### DIFF
--- a/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
@@ -16,7 +16,7 @@ public class EventConverter {
 
 	public Event toEntity(EventRequestDto request) {
 		return Event.createEvent(
-			request.externalId(),
+			request.seq(),
 			request.title(),
 			request.category(),
 			request.startDate(),

--- a/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
@@ -27,7 +27,7 @@ public class EventConverter {
 	public EventResponseDto toResponse(Event event) {
 		return EventResponseDto.builder()
 			.id(event.getId())
-			.name(event.getName())
+			.name(event.getTitle())
 			.category(event.getCategory())
 			.startDate(event.getStartDate())
 			.endDate(event.getEndDate())

--- a/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
@@ -16,6 +16,7 @@ public class EventConverter {
 
 	public Event toEntity(EventRequestDto request) {
 		return Event.createEvent(
+			request.externalId(),
 			request.name(),
 			request.category(),
 			request.startDate(),

--- a/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
@@ -17,7 +17,7 @@ public class EventConverter {
 	public Event toEntity(EventRequestDto request) {
 		return Event.createEvent(
 			request.externalId(),
-			request.name(),
+			request.title(),
 			request.category(),
 			request.startDate(),
 			request.endDate()
@@ -27,7 +27,7 @@ public class EventConverter {
 	public EventResponseDto toResponse(Event event) {
 		return EventResponseDto.builder()
 			.id(event.getId())
-			.name(event.getTitle())
+			.title(event.getTitle())
 			.category(event.getCategory())
 			.startDate(event.getStartDate())
 			.endDate(event.getEndDate())

--- a/src/main/java/com/odit/backend/domain/event/converter/UserEventConverter.java
+++ b/src/main/java/com/odit/backend/domain/event/converter/UserEventConverter.java
@@ -10,7 +10,6 @@ import com.odit.backend.domain.event.dto.request.EventUpdateRequestDto;
 import com.odit.backend.domain.event.dto.response.EventResponseDto;
 import com.odit.backend.domain.event.entity.UserEvent;
 import com.odit.backend.domain.image.entity.EventImage;
-import com.odit.backend.domain.image.entity.UserEventImage;
 
 @Component
 public class UserEventConverter {

--- a/src/main/java/com/odit/backend/domain/event/converter/UserEventConverter.java
+++ b/src/main/java/com/odit/backend/domain/event/converter/UserEventConverter.java
@@ -9,6 +9,7 @@ import com.odit.backend.domain.event.dto.request.EventRequestDto;
 import com.odit.backend.domain.event.dto.request.EventUpdateRequestDto;
 import com.odit.backend.domain.event.dto.response.EventResponseDto;
 import com.odit.backend.domain.event.entity.UserEvent;
+import com.odit.backend.domain.image.entity.EventImage;
 import com.odit.backend.domain.image.entity.UserEventImage;
 
 @Component
@@ -16,8 +17,6 @@ public class UserEventConverter {
 
 	public UserEvent toEntity(EventRequestDto request) {
 		return UserEvent.createEvent(
-			request.startDate(),
-			request.endDate(),
 			request.memo(),
 			false
 		);
@@ -26,14 +25,15 @@ public class UserEventConverter {
 	public EventResponseDto toResponse(UserEvent userEvent) {
 		return EventResponseDto.builder()
 			.id(userEvent.getId())
-			.startDate(userEvent.getCustomStartDate())
-			.endDate(userEvent.getCustomEndDate())
+			.startDate(userEvent.getEvent().getStartDate())
+			.endDate(userEvent.getEvent().getEndDate())
+			.category(userEvent.getEvent().getCategory())
 			.memo(userEvent.getMemo())
 			.visited(userEvent.getVisited())
-			.imageUrlList(Optional.ofNullable(userEvent.getImages())
+			.imageUrlList(Optional.ofNullable(userEvent.getEvent().getImages())
 				.orElse(Collections.emptyList())
 				.stream()
-				.map(UserEventImage::getUrl)
+				.map(EventImage::getUrl)
 				.toList())
 			.build();
 	}

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
@@ -3,19 +3,56 @@ package com.odit.backend.domain.event.dto.request;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "이벤트 등록 요청")
 public record EventRequestDto(
 	@NotBlank(message = "이벤트명은 필수 입력값입니다.")
+	@Schema(
+		description = "이벤트명",
+		example = "Cats",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
 	String name,
 
 	@NotBlank(message = "카테고리는 필수 입력값입니다.")
+	@Schema(
+		description = "카테고리",
+		example = "뮤지컬",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
 	String category,
 
+	@NotBlank(message = "이벤트 시작일자는 필수 입력값입니다.")
+	@Schema(
+		description = "이벤트 시작일시",
+		example = "2024-01-01T10:00:00",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
 	LocalDateTime startDate,
+
+	@NotBlank(message = "이벤트 종료일자는 필수 입력값입니다.")
+	@Schema(
+		description = "이벤트 마감일시",
+		example = "2024-01-01T10:00:00",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
 	LocalDateTime endDate,
+
+	@Schema(
+		description = "사용자 메모",
+		example = "",
+		requiredMode = Schema.RequiredMode.NOT_REQUIRED
+	)
 	String memo,
-	Boolean visited,
+
+	@Schema(
+		description = "관련 이미지 URL 목록",
+		example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]",
+		requiredMode = Schema.RequiredMode.NOT_REQUIRED
+	)
 	List<String> imageUrlList
 ) {
 }

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "이벤트 등록 요청")
 public record EventRequestDto(
@@ -40,7 +41,7 @@ public record EventRequestDto(
 	@JsonFormat(pattern = "yyyyMMdd")
 	LocalDate startDate,
 
-	@NotBlank(message = "이벤트 종료일자는 필수 입력값입니다.")
+	@NotNull(message = "이벤트 종료일자는 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트 마감일시",
 		example = "20250718",

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
@@ -20,7 +20,7 @@ public record EventRequestDto(
 		example = "Cats",
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
-	String name,
+	String title,
 
 	@NotBlank(message = "카테고리는 필수 입력값입니다.")
 	@Schema(

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
@@ -1,14 +1,12 @@
 package com.odit.backend.domain.event.dto.request;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "이벤트 등록 요청")
 public record EventRequestDto(

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
@@ -9,6 +9,11 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "이벤트 등록 요청")
 public record EventRequestDto(
+	@Schema(
+		description = "문화정보 API에서 가져온 문화정보 ID",
+		example = "2432452"
+	)
+	Long externalId,
 	@NotBlank(message = "이벤트명은 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트명",

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
@@ -1,7 +1,10 @@
 package com.odit.backend.domain.event.dto.request;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -33,18 +36,20 @@ public record EventRequestDto(
 	@NotBlank(message = "이벤트 시작일자는 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트 시작일시",
-		example = "2024-01-01T10:00:00",
+		example = "20250718",
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
-	LocalDateTime startDate,
+	@JsonFormat(pattern = "yyyyMMdd")
+	LocalDate startDate,
 
 	@NotBlank(message = "이벤트 종료일자는 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트 마감일시",
-		example = "2024-01-01T10:00:00",
+		example = "20250718",
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
-	LocalDateTime endDate,
+	@JsonFormat(pattern = "yyyyMMdd")
+	LocalDate endDate,
 
 	@Schema(
 		description = "사용자 메모",

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventRequestDto.java
@@ -10,10 +10,10 @@ import jakarta.validation.constraints.NotNull;
 @Schema(description = "이벤트 등록 요청")
 public record EventRequestDto(
 	@Schema(
-		description = "문화정보 API에서 가져온 문화정보 ID",
+		description = "문화정보 API에서 가져온 ",
 		example = "2432452"
 	)
-	Long externalId,
+	Long seq,
 	@NotBlank(message = "이벤트명은 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트명",

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
@@ -14,7 +14,7 @@ public record EventUpdateRequestDto(
 		example = "Cats",
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
-	String name,
+	String title,
 
 	@NotBlank(message = "카테고리는 필수 입력값입니다.")
 	@Schema(

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.odit.backend.domain.event.dto.request;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -27,18 +28,18 @@ public record EventUpdateRequestDto(
 	@NotBlank(message = "이벤트 시작일자는 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트 시작일시",
-		example = "2024-01-01 10:00:00",
+		example = "20250718",
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
-	LocalDateTime startDate,
+	LocalDate startDate,
 
 	@NotBlank(message = "이벤트 종료일자는 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트 마감일시",
-		example = "2024-01-01 10:00:00",
+		example = "20250718",
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
-	LocalDateTime endDate,
+	LocalDate endDate,
 
 	@Schema(
 		description = "사용자 메모",

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
@@ -1,7 +1,6 @@
 package com.odit.backend.domain.event.dto.request;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "이벤트 업데이트 요청")
 public record EventUpdateRequestDto(
@@ -24,7 +24,7 @@ public record EventUpdateRequestDto(
 	)
 	String category,
 
-	@NotBlank(message = "이벤트 시작일자는 필수 입력값입니다.")
+	@NotNull(message = "이벤트 시작일자는 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트 시작일시",
 		example = "20250718",
@@ -32,7 +32,7 @@ public record EventUpdateRequestDto(
 	)
 	LocalDate startDate,
 
-	@NotBlank(message = "이벤트 종료일자는 필수 입력값입니다.")
+	@NotNull(message = "이벤트 종료일자는 필수 입력값입니다.")
 	@Schema(
 		description = "이벤트 마감일시",
 		example = "20250718",

--- a/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/request/EventUpdateRequestDto.java
@@ -2,24 +2,56 @@ package com.odit.backend.domain.event.dto.request;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
+
+@Schema(description = "이벤트 업데이트 요청")
 public record EventUpdateRequestDto(
-    @NotBlank(message = "이벤트명은 필수 입력값입니다.")
-    String name,
+	@NotBlank(message = "이벤트명은 필수 입력값입니다.")
+	@Schema(
+		description = "이벤트명",
+		example = "Cats",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
+	String name,
 
-    @NotBlank(message = "카테고리는 필수 입력값입니다.")
-    String category,
+	@NotBlank(message = "카테고리는 필수 입력값입니다.")
+	@Schema(
+		description = "카테고리",
+		example = "뮤지컬",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
+	String category,
 
-    @NotNull(message = "시작일은 필수 입력값입니다.")
-    LocalDateTime startDate,
+	@NotBlank(message = "이벤트 시작일자는 필수 입력값입니다.")
+	@Schema(
+		description = "이벤트 시작일시",
+		example = "2024-01-01 10:00:00",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
+	LocalDateTime startDate,
 
-    @NotNull(message = "종료일은 필수 입력값입니다.")
-    LocalDateTime endDate,
+	@NotBlank(message = "이벤트 종료일자는 필수 입력값입니다.")
+	@Schema(
+		description = "이벤트 마감일시",
+		example = "2024-01-01 10:00:00",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
+	LocalDateTime endDate,
 
-    String memo,
+	@Schema(
+		description = "사용자 메모",
+		example = "",
+		requiredMode = Schema.RequiredMode.NOT_REQUIRED
+	)
+	String memo,
 
-    Boolean visited
+	@Schema(
+		description = "방문 여부",
+		example = "false",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
+	Boolean visited
 ) {
 }

--- a/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
@@ -19,7 +19,7 @@ public record EventResponseDto(
 		description = "이벤트명",
 		example = "Cats"
 	)
-	String name,
+	String title,
 
 	@Schema(
 		description = "카테고리",

--- a/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
@@ -3,16 +3,56 @@ package com.odit.backend.domain.event.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "이벤트 응답")
 public record EventResponseDto(
+	@Schema(
+		description = "Event ID",
+		example = "2"
+	)
 	Long id,
+	@Schema(
+		description = "이벤트명",
+		example = "Cats"
+	)
 	String name,
+
+	@Schema(
+		description = "카테고리",
+		example = "뮤지컬"
+	)
 	String category,
+
+	@Schema(
+		description = "이벤트 시작일시",
+		example = "2024-01-01T10:00:00"
+	)
 	LocalDateTime startDate,
+
+	@Schema(
+		description = "이벤트 마감일시",
+		example = "2024-01-01T10:00:00"
+	)
 	LocalDateTime endDate,
+
+	@Schema(
+		description = "사용자 메모"
+	)
 	String memo,
+
+	@Schema(
+		description = "방문 여부",
+		example = "false"
+	)
 	Boolean visited,
+
+	@Schema(
+		description = "관련 이미지 URL 목록",
+		example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]"
+	)
 	List<String> imageUrlList) {
 }

--- a/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
@@ -1,11 +1,9 @@
 package com.odit.backend.domain.event.dto.response;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
@@ -28,7 +28,7 @@ public record EventResponseDto(
 
 	@Schema(
 		description = "이벤트 시작일시",
-		example = "20250718"
+		example = "2025-07-18"
 	)
 	LocalDate startDate,
 

--- a/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
@@ -1,5 +1,6 @@
 package com.odit.backend.domain.event.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -29,15 +30,15 @@ public record EventResponseDto(
 
 	@Schema(
 		description = "이벤트 시작일시",
-		example = "2024-01-01T10:00:00"
+		example = "20250718"
 	)
-	LocalDateTime startDate,
+	LocalDate startDate,
 
 	@Schema(
 		description = "이벤트 마감일시",
-		example = "2024-01-01T10:00:00"
+		example = "20250718"
 	)
-	LocalDateTime endDate,
+	LocalDate endDate,
 
 	@Schema(
 		description = "사용자 메모"

--- a/src/main/java/com/odit/backend/domain/event/dto/response/UserEventImageResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/UserEventImageResponseDto.java
@@ -1,8 +1,6 @@
 package com.odit.backend.domain.event.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/odit/backend/domain/event/dto/response/UserEventImageResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/UserEventImageResponseDto.java
@@ -1,15 +1,25 @@
 package com.odit.backend.domain.event.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record UserEventImageResponseDto(
-	@NotNull(message = "이벤트 이미지 ID는 필수입니다.")
+	@Schema(
+		description = "Event ID",
+		example = "2"
+	)
 	Long id,
-	@NotNull(message = "사용자 이벤트 ID는 필수입니다.")
+	@Schema(
+		description = "User Event ID",
+		example = "2"
+	)
 	Long userEventId,
-	@NotBlank(message = "URL은 비어 있을 수 없습니다.")
+	@Schema(
+		description = "업데이트 된 이미지 URL",
+		example = "[\"https://example.com/image2.jpg\"]"
+	)
 	String url) {
 }

--- a/src/main/java/com/odit/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/Event.java
@@ -40,7 +40,7 @@ public class Event extends BaseEntity {
 	private Long externalId;
 
 	@NonNull
-	private String name;
+	private String title;
 
 	@NonNull
 	private String category;
@@ -64,7 +64,7 @@ public class Event extends BaseEntity {
 		LocalDateTime endDate) {
 		Event event = new Event();
 		event.externalId = externalId;
-		event.name = name;
+		event.title = name;
 		event.category = category;
 		event.startDate = startDate;
 		event.endDate = endDate;
@@ -84,7 +84,7 @@ public class Event extends BaseEntity {
 
 	public void updateEvent(EventUpdateRequestDto updateRequest) {
 		if (updateRequest.name() != null)
-			this.name = updateRequest.name();
+			this.title = updateRequest.name();
 		if (updateRequest.category() != null)
 			this.category = updateRequest.category();
 		if (updateRequest.startDate() != null)

--- a/src/main/java/com/odit/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/Event.java
@@ -21,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Builder
 @Getter
@@ -34,16 +35,21 @@ public class Event extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(unique = true, nullable = false)
+	@NonNull
+	@Column(unique = true)
+	private Long externalId;
+
+	@NonNull
 	private String name;
 
-	@Column(nullable = false)
+	@NonNull
 	private String category;
 
-	@Column(nullable = false, name = "start_date")
+	@NonNull
 	private LocalDateTime startDate;
 
-	@Column(nullable = false, name = "end_date")
+	@NonNull
+	@Column(name = "end_date")
 	private LocalDateTime endDate;
 
 	@Builder.Default
@@ -54,8 +60,10 @@ public class Event extends BaseEntity {
 	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<EventImage> images = new ArrayList<>();
 
-	public static Event createEvent(String name, String category, LocalDateTime startDate, LocalDateTime endDate) {
+	public static Event createEvent(Long externalId, String name, String category, LocalDateTime startDate,
+		LocalDateTime endDate) {
 		Event event = new Event();
+		event.externalId = externalId;
 		event.name = name;
 		event.category = category;
 		event.startDate = startDate;

--- a/src/main/java/com/odit/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/Event.java
@@ -37,7 +37,7 @@ public class Event extends BaseEntity {
 
 	@NonNull
 	@Column(unique = true)
-	private Long externalId;
+	private Long seq;
 
 	@NonNull
 	private String title;
@@ -60,10 +60,10 @@ public class Event extends BaseEntity {
 	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<EventImage> images = new ArrayList<>();
 
-	public static Event createEvent(Long externalId, String title, String category, LocalDateTime startDate,
+	public static Event createEvent(Long seq, String title, String category, LocalDateTime startDate,
 		LocalDateTime endDate) {
 		Event event = new Event();
-		event.externalId = externalId;
+		event.seq = seq;
 		event.title = title;
 		event.category = category;
 		event.startDate = startDate;

--- a/src/main/java/com/odit/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/Event.java
@@ -1,6 +1,6 @@
 package com.odit.backend.domain.event.entity;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,11 +46,12 @@ public class Event extends BaseEntity {
 	private String category;
 
 	@NonNull
-	private LocalDateTime startDate;
+	@Column(name = "start_date")
+	private LocalDate startDate;
 
 	@NonNull
 	@Column(name = "end_date")
-	private LocalDateTime endDate;
+	private LocalDate endDate;
 
 	@Builder.Default
 	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -60,8 +61,8 @@ public class Event extends BaseEntity {
 	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<EventImage> images = new ArrayList<>();
 
-	public static Event createEvent(Long seq, String title, String category, LocalDateTime startDate,
-		LocalDateTime endDate) {
+	public static Event createEvent(Long seq, String title, String category, LocalDate startDate,
+		LocalDate endDate) {
 		Event event = new Event();
 		event.seq = seq;
 		event.title = title;

--- a/src/main/java/com/odit/backend/domain/event/entity/Event.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/Event.java
@@ -60,11 +60,11 @@ public class Event extends BaseEntity {
 	@OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<EventImage> images = new ArrayList<>();
 
-	public static Event createEvent(Long externalId, String name, String category, LocalDateTime startDate,
+	public static Event createEvent(Long externalId, String title, String category, LocalDateTime startDate,
 		LocalDateTime endDate) {
 		Event event = new Event();
 		event.externalId = externalId;
-		event.title = name;
+		event.title = title;
 		event.category = category;
 		event.startDate = startDate;
 		event.endDate = endDate;
@@ -83,8 +83,8 @@ public class Event extends BaseEntity {
 	}
 
 	public void updateEvent(EventUpdateRequestDto updateRequest) {
-		if (updateRequest.name() != null)
-			this.title = updateRequest.name();
+		if (updateRequest.title() != null)
+			this.title = updateRequest.title();
 		if (updateRequest.category() != null)
 			this.category = updateRequest.category();
 		if (updateRequest.startDate() != null)

--- a/src/main/java/com/odit/backend/domain/event/entity/UserEvent.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/UserEvent.java
@@ -1,6 +1,5 @@
 package com.odit.backend.domain.event.entity;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,7 +9,6 @@ import com.odit.backend.domain.user.entity.User;
 import com.odit.backend.global.entity.BaseEntity;
 
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -20,7 +18,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Negative;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/odit/backend/domain/event/entity/UserEvent.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/UserEvent.java
@@ -20,11 +20,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Negative;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @Getter
@@ -38,10 +40,12 @@ public class UserEvent extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@NonNull
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
+	@NonNull
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "event_id")
 	private Event event;
@@ -54,6 +58,8 @@ public class UserEvent extends BaseEntity {
 
 	private String memo;
 
+	@NonNull
+	@Negative
 	private Boolean visited;
 
 	@OneToMany(mappedBy = "userEvent", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/odit/backend/domain/event/entity/UserEvent.java
+++ b/src/main/java/com/odit/backend/domain/event/entity/UserEvent.java
@@ -50,27 +50,18 @@ public class UserEvent extends BaseEntity {
 	@JoinColumn(name = "event_id")
 	private Event event;
 
-	@Column(name = "custom_start_date")
-	private LocalDateTime customStartDate;
-
-	@Column(name = "custom_end_date")
-	private LocalDateTime customEndDate;
-
 	private String memo;
 
 	@NonNull
-	@Negative
 	private Boolean visited;
 
 	@OneToMany(mappedBy = "userEvent", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<UserEventImage> images = new ArrayList<>();
 
 	// 팩토리 메서드
-	public static UserEvent createEvent(LocalDateTime startDate, LocalDateTime endDate,
+	public static UserEvent createEvent(
 		String memo, Boolean visited) {
 		UserEvent userEvent = new UserEvent();
-		userEvent.customStartDate = startDate;
-		userEvent.customEndDate = endDate;
 		userEvent.memo = memo;
 		userEvent.visited = visited;
 		return userEvent;
@@ -92,10 +83,6 @@ public class UserEvent extends BaseEntity {
 
 	// 업데이트 메서드
 	public void updateEvent(EventUpdateRequestDto request) {
-		if (request.startDate() != null)
-			this.customStartDate = request.startDate();
-		if (request.endDate() != null)
-			this.customEndDate = request.endDate();
 		if (request.memo() != null)
 			this.memo = request.memo();
 		if (request.visited() != null)

--- a/src/main/java/com/odit/backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/odit/backend/domain/event/repository/EventRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.odit.backend.domain.event.entity.Event;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-  Optional<Event> findByName(String name);
+  Optional<Event> findByTitle(String title);
 
   Optional<Event> findByExternalId(Long externalId);
 }

--- a/src/main/java/com/odit/backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/odit/backend/domain/event/repository/EventRepository.java
@@ -9,5 +9,5 @@ import com.odit.backend.domain.event.entity.Event;
 public interface EventRepository extends JpaRepository<Event, Long> {
   Optional<Event> findByTitle(String title);
 
-  Optional<Event> findByExternalId(Long externalId);
+  Optional<Event> findBySeq(Long seq);
 }

--- a/src/main/java/com/odit/backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/odit/backend/domain/event/repository/EventRepository.java
@@ -8,4 +8,6 @@ import com.odit.backend.domain.event.entity.Event;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
   Optional<Event> findByName(String name);
+
+  Optional<Event> findByExternalId(Long externalId);
 }

--- a/src/main/java/com/odit/backend/domain/event/repository/UserEventRepository.java
+++ b/src/main/java/com/odit/backend/domain/event/repository/UserEventRepository.java
@@ -13,10 +13,10 @@ import com.odit.backend.domain.event.entity.UserEvent;
 @Repository
 public interface UserEventRepository extends JpaRepository<UserEvent, Long> {
 
-	@Query("SELECT ue FROM UserEvent ue WHERE DATE(ue.customStartDate) = :date")
+	@Query("SELECT ue FROM UserEvent ue WHERE DATE(ue.event.startDate) = :date")
 	List<UserEvent> findByDate(@Param("date") LocalDate date);
 
-	@Query("SELECT ue FROM UserEvent ue WHERE ue.customStartDate IS NULL AND ue.customEndDate IS NULL")
+	@Query("SELECT ue FROM UserEvent ue WHERE ue.event.startDate IS NULL AND ue.event.endDate IS NULL")
 	List<UserEvent> findNoDateEvents();
 
 	@Query("SELECT ue FROM UserEvent ue ORDER BY ue.visited DESC")

--- a/src/main/java/com/odit/backend/domain/event/service/command/EventCommandService.java
+++ b/src/main/java/com/odit/backend/domain/event/service/command/EventCommandService.java
@@ -25,7 +25,7 @@ public class EventCommandService {
 	private final EventQueryService eventQueryService;
 
 	public Event saveOrFindEvent(EventRequestDto request) {
-		return eventQueryService.getEventByExternalId(request.externalId()).orElseGet(() -> createNewEvent(request));
+		return eventQueryService.getEventBySeq(request.seq()).orElseGet(() -> createNewEvent(request));
 	}
 
 	private Event createNewEvent(EventRequestDto request) {

--- a/src/main/java/com/odit/backend/domain/event/service/command/EventCommandService.java
+++ b/src/main/java/com/odit/backend/domain/event/service/command/EventCommandService.java
@@ -7,6 +7,7 @@ import com.odit.backend.domain.event.converter.EventConverter;
 import com.odit.backend.domain.event.dto.request.EventRequestDto;
 import com.odit.backend.domain.event.entity.Event;
 import com.odit.backend.domain.event.repository.EventRepository;
+import com.odit.backend.domain.event.service.query.EventQueryService;
 import com.odit.backend.domain.image.service.command.EventImageCommandService;
 
 import lombok.AccessLevel;
@@ -21,15 +22,18 @@ public class EventCommandService {
 	private final EventRepository eventRepository;
 	private final EventConverter eventConverter;
 	private final EventImageCommandService eventImageCommandService;
+	private final EventQueryService eventQueryService;
 
 	public Event saveOrFindEvent(EventRequestDto request) {
-		return eventRepository.findByName(request.name()).orElseGet(() -> {
-			Event event = eventConverter.toEntity(request);
-			eventRepository.save(event);
-			if (!request.imageUrlList().isEmpty()) {
-				eventImageCommandService.addImageToEvent(request, event);
-			}
-			return event;
-		});
+		return eventQueryService.getEventByExternalId(request.externalId()).orElseGet(() -> createNewEvent(request));
+	}
+
+	private Event createNewEvent(EventRequestDto request) {
+		Event event = eventConverter.toEntity(request);
+		Event savedEvent = eventRepository.save(event);
+		if (!request.imageUrlList().isEmpty()) {
+			eventImageCommandService.addImageToEvent(request, savedEvent);
+		}
+		return savedEvent;
 	}
 }

--- a/src/main/java/com/odit/backend/domain/event/service/query/EventQueryService.java
+++ b/src/main/java/com/odit/backend/domain/event/service/query/EventQueryService.java
@@ -22,8 +22,8 @@ public class EventQueryService {
 
 	private final EventRepository eventRepository;
 
-	public Event getEventByName(String eventName) {
-		return eventRepository.findByName(eventName)
+	public Event getEventByTitle(String eventName) {
+		return eventRepository.findByTitle(eventName)
 			.orElseThrow(() -> new EventException(GlobalErrorCode.COMMON_EVENT_NOT_FOUND));
 	}
 

--- a/src/main/java/com/odit/backend/domain/event/service/query/EventQueryService.java
+++ b/src/main/java/com/odit/backend/domain/event/service/query/EventQueryService.java
@@ -1,5 +1,7 @@
 package com.odit.backend.domain.event.service.query;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,5 +25,9 @@ public class EventQueryService {
 	public Event getEventByName(String eventName) {
 		return eventRepository.findByName(eventName)
 			.orElseThrow(() -> new EventException(GlobalErrorCode.COMMON_EVENT_NOT_FOUND));
+	}
+
+	public Optional<Event> getEventByExternalId(long externalId) {
+		return eventRepository.findByExternalId(externalId);
 	}
 }

--- a/src/main/java/com/odit/backend/domain/event/service/query/EventQueryService.java
+++ b/src/main/java/com/odit/backend/domain/event/service/query/EventQueryService.java
@@ -27,7 +27,7 @@ public class EventQueryService {
 			.orElseThrow(() -> new EventException(GlobalErrorCode.COMMON_EVENT_NOT_FOUND));
 	}
 
-	public Optional<Event> getEventByExternalId(long externalId) {
-		return eventRepository.findByExternalId(externalId);
+	public Optional<Event> getEventBySeq(long seq) {
+		return eventRepository.findBySeq(seq);
 	}
 }

--- a/src/main/java/com/odit/backend/domain/notification/converter/NotificationEventConverter.java
+++ b/src/main/java/com/odit/backend/domain/notification/converter/NotificationEventConverter.java
@@ -38,13 +38,13 @@ public class NotificationEventConverter {
 
 	/* EVENT_START_SOON */
 	public NotificationEvent toStartEvent(UserEvent userEvent, int remainingDays) {
-		String content = String.format("'%s'이 %d일 뒤 시작해요!", userEvent.getEvent().getName(), remainingDays);
+		String content = String.format("'%s'이 %d일 뒤 시작해요!", userEvent.getEvent().getTitle(), remainingDays);
 		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_START_SOON, content);
 	}
 
 	/* EVENT_DURATION_MISSING */
 	public NotificationEvent toMissingEvent(UserEvent userEvent) {
-		String content = String.format("'%s' 기간을 아직 입력하지 않았어요!", userEvent.getEvent().getName());
+		String content = String.format("'%s' 기간을 아직 입력하지 않았어요!", userEvent.getEvent().getTitle());
 		return createNotificationEvent(userEvent.getUser().getEmail(), EVENT_DURATION_MISSING, content);
 	}
 
@@ -53,7 +53,7 @@ public class NotificationEventConverter {
 		if (userEvents == null || userEvents.isEmpty()) {
 			throw new IllegalArgumentException("이벤트 리스트에 하나 이상의 요소가 존재해야 합니다.");
 		}
-		String primaryEventName = userEvents.get(0).getEvent().getName();
+		String primaryEventName = userEvents.get(0).getEvent().getTitle();
 		int remainingCount = userEvents.size() - 1;
 		String content = String.format("'%s'외 %d개의 이벤트 기간을 아직 입력하지 않았어요!", primaryEventName, remainingCount);
 		return createNotificationEvent(userEvents.get(0).getUser().getEmail(), EVENT_DURATION_MISSING, content);


### PR DESCRIPTION
## 💡 작업 내용

- [x] 문화포털 API 기반 이벤트 등록 API 수정

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)
 - Place와 달리 별도로 저장되고 있던 Event 관련 데이터를 문화포털 API 기반의 데이터 저장 및 중복검사를 시행할 수 있도록 이벤트 생성 로직을 수정했습니다.
 - Swagger 문서 가독성을 위한 `@Schema`을 이용하여 명확하게 데이터를 표현했습니다.
 - 문화포털 API 제공하는 데이터 형식을 기반으로 속성값과 DTO 파라미터 타입을 수정했습니다.

## 📗 참고 자료 (선택)
closes #162
## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트에 고유 식별자인 seq 필드가 추가되었습니다.

* **기능 개선**
  * 이벤트의 name 필드가 title로 변경되어 더 명확하게 표시됩니다.
  * 이벤트 시작일과 종료일이 LocalDate 타입으로 변경되어 날짜 입력 및 표시가 간소화되었습니다.
  * 이벤트 관련 API 요청 및 응답에 Swagger 문서화가 강화되어, 필드별 설명과 예시가 추가되었습니다.
  * UserEvent의 커스텀 날짜 필드가 제거되고, 이벤트의 날짜 정보를 참조하도록 개선되었습니다.
  * 이벤트 조회 및 생성 로직이 name 기반에서 seq 또는 title 기반으로 변경되어 중복 생성 및 조회 오류가 줄어듭니다.
  * 이벤트 이미지 처리 로직이 개선되어 이미지 추가가 안정적으로 처리됩니다.

* **버그 수정**
  * 이벤트 알림 메시지에서 이벤트 식별자가 name에서 title로 변경되어 알림 내용이 정확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->