### PR TITLE
[Refactor] 소셜 로그인 리다이렉트 URL 수정

### DIFF
--- a/src/main/java/com/odit/backend/domain/auth/service/AbstractOAuth2UserService.java
+++ b/src/main/java/com/odit/backend/domain/auth/service/AbstractOAuth2UserService.java
@@ -58,11 +58,7 @@ public abstract class AbstractOAuth2UserService extends SimpleUrlAuthenticationS
 		log.debug("[Token] 리프레시 토큰 쿠키 생성 - name: {}, maxAge: {}", refreshTokenCookieName, cookie.getMaxAge());
 	}
 
-	protected String determineRedirectUrl(HttpServletRequest request) {
-		if (request.getHeader("Referer") != null && request.getHeader("Referer").contains(FRONT_PORT)) {
-			return FRONT_REDIRECT_URI;
-		} else {
-			return baseUrl;
-		}
+	protected String determineRedirectUrl() {
+		return baseUrl;
 	}
 }

--- a/src/main/java/com/odit/backend/domain/auth/service/GoogleOAuth2UserService.java
+++ b/src/main/java/com/odit/backend/domain/auth/service/GoogleOAuth2UserService.java
@@ -59,7 +59,7 @@ public class GoogleOAuth2UserService extends AbstractOAuth2UserService {
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		String redirectUrl = determineRedirectUrl(request);
+		String redirectUrl = determineRedirectUrl();
 		log.debug("[Google OAuth2] 리다이렉션 URL: {}", redirectUrl);
 		response.sendRedirect(redirectUrl);
 	}

--- a/src/main/java/com/odit/backend/domain/auth/service/KakaoOAuth2UserService.java
+++ b/src/main/java/com/odit/backend/domain/auth/service/KakaoOAuth2UserService.java
@@ -66,7 +66,7 @@ public class KakaoOAuth2UserService extends AbstractOAuth2UserService {
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		String redirectUrl = determineRedirectUrl(request);
+		String redirectUrl = determineRedirectUrl();
 		log.debug("[Kakao OAuth2] 리다이렉션 URL: {}", redirectUrl);
 		response.sendRedirect(redirectUrl);
 	}

--- a/src/main/java/com/odit/backend/domain/auth/service/NaverOAuth2UserService.java
+++ b/src/main/java/com/odit/backend/domain/auth/service/NaverOAuth2UserService.java
@@ -61,7 +61,7 @@ public class NaverOAuth2UserService extends AbstractOAuth2UserService {
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		String redirectUrl = determineRedirectUrl(request);
+		String redirectUrl = determineRedirectUrl();
 		log.debug("[Naver OAuth2] 리다이렉션 URL: {}", redirectUrl);
 		response.sendRedirect(redirectUrl);
 	}

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -40,7 +40,7 @@ spring:
       port: 6379
 
 
-base-url: ${SERVER_BASE_URL}
+base-url: ${FRONT_LOCAL_URL}/login/oauth
 
 redirect:
   kakaoUrl: ${SERVER_BASE_URL}/login/oauth2/code/kakao

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -39,7 +39,7 @@ spring:
       host: redis
       port: 6379
 
-base-url: ${SERVER_BASE_URL}
+base-url: ${FRONT_LOCAL_URL}/login/oauth
 
 redirect:
   kakaoUrl: ${SERVER_BASE_URL}/login/oauth2/code/kakao


### PR DESCRIPTION
## 💡 작업 내용

- [ ] 소셜 로그인 리다이렉트 URL을 FRONT_BASE_URL로 변경 진행

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 불필요한 코드는 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 소셜 로그인 인증 후 리다이렉트 URL이 항상 동일한 경로로 이동하도록 수정되었습니다.

* **환경설정**
  * 로그인 후 리다이렉트되는 기본 URL 설정이 변경되어, 프론트엔드의 `/login/oauth` 경로로 이동하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->