### PR TITLE
[refactor]: 장소 등록 로직 수정

### DIFF
--- a/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/odit/backend/domain/event/converter/EventConverter.java
@@ -36,6 +36,7 @@ public class EventConverter {
 				.stream()
 				.map(EventImage::getUrl)
 				.toList())
+			.seq(event.getSeq())
 			.build();
 	}
 

--- a/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/event/dto/response/EventResponseDto.java
@@ -53,5 +53,12 @@ public record EventResponseDto(
 		description = "관련 이미지 URL 목록",
 		example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]"
 	)
-	List<String> imageUrlList) {
+	List<String> imageUrlList,
+	@Schema(
+		description = "문화정보 API에서 가져온 ",
+		example = "2432452"
+	)
+	Long seq
+	)
+{
 }

--- a/src/main/java/com/odit/backend/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/com/odit/backend/domain/place/converter/PlaceConverter.java
@@ -15,9 +15,9 @@ import com.odit.backend.domain.place.entity.UserPlace;
 
 @Component
 public class PlaceConverter {
-	public Place toEntity(PlaceRequestDto requestDto, Long placeId) {
+	public Place toEntity(PlaceRequestDto requestDto, Long sequence) {
 		return Place.builder()
-			.seq(placeId)
+			.seq(sequence)
 			.placeName(requestDto.placeName())
 			.addressName(requestDto.addressName())
 			.latitude(requestDto.latitude())

--- a/src/main/java/com/odit/backend/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/com/odit/backend/domain/place/converter/PlaceConverter.java
@@ -17,7 +17,7 @@ import com.odit.backend.domain.place.entity.UserPlace;
 public class PlaceConverter {
 	public Place toEntity(PlaceRequestDto requestDto, Long placeId) {
 		return Place.builder()
-			.id(placeId)
+			.seq(placeId)
 			.placeName(requestDto.placeName())
 			.addressName(requestDto.addressName())
 			.latitude(requestDto.latitude())

--- a/src/main/java/com/odit/backend/domain/place/dto/request/PlaceRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/place/dto/request/PlaceRequestDto.java
@@ -1,43 +1,77 @@
 package com.odit.backend.domain.place.dto.request;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
-
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.odit.backend.domain.place.entity.Place;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
  * DTO for {@link Place}
  */
+public record PlaceRequestDto(
+	@Schema(
+		description = "링크 추출 후 얻은 장소명",
+		example = "스타벅스"
+	)
+	@NotBlank(message = "장소명은 필수 입력값입니다.")
+	String placeName,
+	@Schema(
+		description = "해당 장소의 위도",
+		example = "37.5665"
+	)
+	@NotNull(message = "위도는 필수 입력값입니다.")
+	BigDecimal latitude,
 
-@JsonInclude(NON_NULL)
-public record PlaceRequestDto(@NotBlank(message = "장소명은 필수 입력값입니다.")
-							  String placeName,
+	@Schema(
+		description = "해당 장소의 경도",
+		example = "127.0458"
+	)
+	@NotNull(message = "경도는 필수 입력값입니다.")
+	BigDecimal longitude,
 
-							  @NotNull(message = "위도는 필수 입력값입니다.")
-							  BigDecimal latitude,
+	@Schema(
+		description = "해당 장소의 지번 주소",
+		example = "서울 강남구 삼성동 159"
+	)
+	@NotBlank(message = "지번 주소는 필수 입력값입니다.")
+	String addressName,
 
-							  @NotNull(message = "경도는 필수 입력값입니다.")
-							  BigDecimal longitude,
+	@Schema(
+		description = "해당 장소의 도로명 주소",
+		example = "서울 강남구 영동대로 513"
+	)
+	@NotBlank(message = "도로명 주소는 필수 입력값입니다.")
+	String roadAddressName,
 
-							  @NotBlank(message = "지번 주소는 필수 입력값입니다.")
-							  String addressName,
+	@Schema(
+		description = "해당 장소가 속한 카테고리",
+		example = "음식점"
+	)
+	@NotBlank(message = "카테고리는 필수 입력값입니다.")
+	String subCategory,
 
-							  @NotBlank(message = "도로명 주소는 필수 입력값입니다.")
-							  String roadAddressName,
+	@Schema(
+		description = "문화정보 API에서 가져온 ",
+		example = "2432452"
+	)
+	@NotBlank(message = "링크는 필수 입력값입니다.")
+	String url,
 
-							  @NotBlank(message = "카테고리는 필수 입력값입니다.")
-							  String subCategory,
+	@Schema(
+		description = "카카오 맵 url",
+		example = "https://place.map.kakao.com/1382220123"
+	)
+	String memo,
 
-							  @NotBlank(message = "링크는 필수 입력값입니다.")
-							  String url,
-							  String memo,
-							  List<String> imageUrlList)
+	@Schema(
+		description = "해당 장소의 이미지",
+		example = "이미지 url"
+	)
+	List<String> imageUrlList)
 	implements Serializable {
 }

--- a/src/main/java/com/odit/backend/domain/place/dto/request/PlaceRequestDto.java
+++ b/src/main/java/com/odit/backend/domain/place/dto/request/PlaceRequestDto.java
@@ -13,6 +13,8 @@ import jakarta.validation.constraints.NotNull;
 /**
  * DTO for {@link Place}
  */
+
+@Schema(description = "장소 등록 요청")
 public record PlaceRequestDto(
 	@Schema(
 		description = "링크 추출 후 얻은 장소명",
@@ -21,56 +23,55 @@ public record PlaceRequestDto(
 	@NotBlank(message = "장소명은 필수 입력값입니다.")
 	String placeName,
 	@Schema(
-		description = "해당 장소의 위도",
+		description = "장소의 위도",
 		example = "37.5665"
 	)
 	@NotNull(message = "위도는 필수 입력값입니다.")
 	BigDecimal latitude,
 
 	@Schema(
-		description = "해당 장소의 경도",
+		description = "장소의 경도",
 		example = "127.0458"
 	)
 	@NotNull(message = "경도는 필수 입력값입니다.")
 	BigDecimal longitude,
 
 	@Schema(
-		description = "해당 장소의 지번 주소",
+		description = "장소의 지번 주소",
 		example = "서울 강남구 삼성동 159"
 	)
 	@NotBlank(message = "지번 주소는 필수 입력값입니다.")
 	String addressName,
 
 	@Schema(
-		description = "해당 장소의 도로명 주소",
+		description = "장소의 도로명 주소",
 		example = "서울 강남구 영동대로 513"
 	)
 	@NotBlank(message = "도로명 주소는 필수 입력값입니다.")
 	String roadAddressName,
 
 	@Schema(
-		description = "해당 장소가 속한 카테고리",
+		description = "장소가 속한 카테고리",
 		example = "음식점"
 	)
 	@NotBlank(message = "카테고리는 필수 입력값입니다.")
 	String subCategory,
 
 	@Schema(
-		description = "문화정보 API에서 가져온 ",
-		example = "2432452"
+		description = "카카오 맵 url",
+		example = "https://place.map.kakao.com/1382220123"
 	)
 	@NotBlank(message = "링크는 필수 입력값입니다.")
 	String url,
 
 	@Schema(
-		description = "카카오 맵 url",
-		example = "https://place.map.kakao.com/1382220123"
+		description = "사용자가 입력한 메모",
+		example = "분위기 좋은 카페"
 	)
 	String memo,
 
 	@Schema(
-		description = "해당 장소의 이미지",
-		example = "이미지 url"
+		description = "장소의 이미지 url 리스트"
 	)
 	List<String> imageUrlList)
 	implements Serializable {

--- a/src/main/java/com/odit/backend/domain/place/dto/response/FriendPlaceResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/place/dto/response/FriendPlaceResponseDto.java
@@ -4,7 +4,27 @@ import java.util.List;
 
 import com.odit.backend.domain.user.dto.response.UserResponse;
 
-public record FriendPlaceResponseDto(PlaceResponseDto place,
-									 List<UserResponse.InfoDto> userList){
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "친구 장소 응답")
+public record FriendPlaceResponseDto(
+
+	@Schema(
+		description = "place에 대한 정보",
+		example = "placeResponseDto 를 참고"
+	)
+	PlaceResponseDto place,
+
+
+	@Schema(
+		description = "해당 장소를 저장한 친구의 정보",
+		example = "ID : 1"
+			+ "email : hello@kakao.com"
+		    + "name : 전규진"
+		    + "nickname : 규진"
+			+ "role : Quest"
+			+ "profile : http://k.kakaocdn.net/dn/c6s5g4/btsEtkScM1S/2496XzpgkN4SW7HKFvvcT0/img_640x640.jpg"
+	)
+	List<UserResponse.InfoDto> userList){
 
 }

--- a/src/main/java/com/odit/backend/domain/place/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/place/dto/response/PlaceResponseDto.java
@@ -5,54 +5,95 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "장소 응답")
 public record PlaceResponseDto(
-	@NotNull(message = "장소 아이디는 필수 입력값입니다.")
+
+
+	@Schema(
+		description = "place Id",
+		example = "1"
+	)
 	Long placeId,
 
-	@NotNull(message = "사용자 장소 아이디는 필수 입력값입니다.")
+	@Schema(
+		description = "userPlace Id",
+		example = "1"
+	)
 	Long userPlaceId,
 
-	@NotBlank(message = "메모는 빈 값일 수 없습니다.")
+	@Schema(
+		description = "사용자 메모"
+	)
 	String memo,
 
-	@NotNull(message = "방문 여부는 필수 입력값입니다.")
+	@Schema(
+		description = "해당 장소 방문여부",
+		example = "true"
+	)
 	Boolean visited,
 
-	@NotBlank(message = "장소명은 빈 값일 수 없습니다.")
+	@Schema(
+		description = "장소 이름",
+		example = "스타벅스"
+	)
 	String placeName,
 
-	@NotNull(message = "위도는 필수 입력값입니다.")
+	@Schema(
+		description = "장소 위도",
+		example = "37.5665"
+	)
 	BigDecimal latitude,
 
-	@NotNull(message = "경도는 필수 입력값입니다.")
+	@Schema(
+		description = "장소 경도",
+		example = "127.0458"
+	)
 	BigDecimal longitude,
 
-	@NotBlank(message = "카테고리는 빈 값일 수 없습니다.")
+	@Schema(
+		description = "장소 카테고리",
+		example = "음식점"
+	)
 	String subCategory,
 
-	@NotBlank(message = "도로명 주소는 빈 값일 수 없습니다.")
+	@Schema(
+		description = "장소의 도로명 주소",
+		example = "서울 강남구 영동대로 513"
+	)
 	String roadAddressName,
 
-	@NotBlank(message = "지번 주소는 빈 값일 수 없습니다.")
+	@Schema(
+		description = "장소의 지번 주소",
+		example = "서울 강남구 삼성동 159"
+	)
 	String addressName,
 
-	@NotBlank(message = "URL은 빈 값일 수 없습니다.")
+	@Schema(
+		description = "카카오 맵 url",
+		example = "https://place.map.kakao.com/1382220123"
+	)
 	String url,
 
-	@Nullable
+	@Schema(
+		description = "장소 이미지 url 리스트"
+	)
 	List<String> imageUrlList,
 
-	@NotNull(message = "친구 사용자 아이디는 필수 입력값입니다.")
+	@Schema(
+		description = "친구 Id",
+		example = "1"
+	)
 	Long friendUserId,
 
-	@NotBlank(message = "프로필은 빈 값일 수 없습니다.")
+	@Schema(
+		description = "사용자의 profile",
+		example = "http://k.kakaocdn.net/dn/c6s5g4/btsEtkScM1S/2496XzpgkN4SW7HKFvvcT0/img_640x640.jpg"
+	)
 	String profile
 ) {
 }

--- a/src/main/java/com/odit/backend/domain/place/dto/response/UserPlaceImageResponseDto.java
+++ b/src/main/java/com/odit/backend/domain/place/dto/response/UserPlaceImageResponseDto.java
@@ -1,15 +1,23 @@
 package com.odit.backend.domain.place.dto.response;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record UserPlaceImageResponseDto(
-	@NotNull(message = "사용자 장소 이미지 ID는 필수입니다.")
+	@Schema(
+		description = "userPlaceImage Id",
+		example = "1"
+	)
 	Long userPlaceImageId,
-	@NotNull(message = "사용자 장소 ID는 필수입니다.")
+	@Schema(
+		description = "userPlace Id",
+		example = "1"
+	)
 	Long userPlaceId,
-	@NotBlank(message = "URL은 비어 있을 수 없습니다.")
+	@Schema(
+		description = "업데이트 된 이미지 URL",
+		example = "[\"https://example.com/image2.jpg\"]"
+	)
 	String url) {
 }

--- a/src/main/java/com/odit/backend/domain/place/entity/Place.java
+++ b/src/main/java/com/odit/backend/domain/place/entity/Place.java
@@ -11,6 +11,8 @@ import com.odit.backend.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -28,8 +30,11 @@ import lombok.NoArgsConstructor;
 @Table(name = "place")
 public class Place extends BaseEntity {
 
-	@Id
+	@Id@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Column(unique = true, nullable = false)
+	private Long seq;
 
 	@Column(nullable = false)
 	private String placeName;

--- a/src/main/java/com/odit/backend/domain/place/entity/UserPlace.java
+++ b/src/main/java/com/odit/backend/domain/place/entity/UserPlace.java
@@ -44,6 +44,7 @@ public class UserPlace extends BaseEntity {
 	private Place place;
 
 	@OneToMany(mappedBy = "userPlace", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
 	private List<UserPlaceImage> images = new ArrayList<>();
 
 	private String memo;

--- a/src/main/java/com/odit/backend/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/odit/backend/domain/place/repository/PlaceRepository.java
@@ -16,4 +16,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
 	@Query("SELECT p FROM Place p where p.placeName LIKE %:placeName%")
 	Optional<Place> findByBusinessName(@Param("placeName") String businessName);
+
+	@Query("SELECT p FROM Place p where p.seq = :seq")
+	Optional<Place> findBySequence(@Param("seq") Long sequence);
 }

--- a/src/main/java/com/odit/backend/domain/place/service/command/PlaceCommandService.java
+++ b/src/main/java/com/odit/backend/domain/place/service/command/PlaceCommandService.java
@@ -28,9 +28,9 @@ public class PlaceCommandService {
 
 	// 카카오맵 url -> 기존 공통 장소 반환 or 새로운 공통 장소 생성
 	public Place saveOrFindPlace(PlaceRequestDto request) {
-		Long placeId = extractTrailingDigits(request.url());
-		return placeRepository.findById(placeId).orElseGet(() -> {
-			Place place = placeConverter.toEntity(request, placeId);
+		Long sequence = extractTrailingDigits(request.url());
+		return placeRepository.findBySequence(sequence).orElseGet(() -> {
+			Place place = placeConverter.toEntity(request, sequence);
 			placeRepository.save(place);
 			if (!request.imageUrlList().isEmpty()) {
 				placeImageCommandService.addNewPlaceImage(request, place);


### PR DESCRIPTION
## 💡 작업 내용

- [ ] 장소 등록 수정

## 💡 자세한 설명
장소 등록 시, 기본키를 @GeneratedValue로 바꾸고, 카카오 맵 url의 일련변호를 seq에 설정

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 불필요한 코드는 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 장소에 고유하고 필수적인 시퀀스(seq) 필드가 추가되었습니다.
  * 장소 조회에 시퀀스 기반 검색이 도입되었습니다.
  * 문화 행사 응답에도 시퀀스 필드가 추가되어 식별 정보가 제공됩니다.
  * 사용자 장소 이미지 목록이 빌더 사용 시 기본 빈 리스트로 초기화되어 null 방지가 개선되었습니다.

* **버그 수정**
  * 장소의 기본 ID가 데이터베이스에서 자동 생성되도록 개선되었습니다.

* **문서 개선**
  * 요청/응답 DTO에 상세한 API 설명과 예시가 추가되어 문서화가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->