### PR TITLE
[fix]: 구글 로그인 성공 시 accessToken을 임시로 URL 파라미터로 전달

### DIFF
--- a/src/main/java/com/odit/backend/domain/auth/service/GoogleOAuth2UserService.java
+++ b/src/main/java/com/odit/backend/domain/auth/service/GoogleOAuth2UserService.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class GoogleOAuth2UserService extends AbstractOAuth2UserService {
 
+	private final String FRONT_LOCAL_URL = "http://localhost:3000";
+
 	protected GoogleOAuth2UserService(JwtTokenProvider jwtTokenProvider,
 		RefreshTokenRepository refreshTokenRepository,
 		UserCommandService userCommandService) {
@@ -59,7 +61,8 @@ public class GoogleOAuth2UserService extends AbstractOAuth2UserService {
 		refreshTokenRepository.save(refreshToken);
 		addRefreshTokenToCookie(newRefreshToken, response);
 
-		String redirectUrl = determineRedirectUrl();
+		//String redirectUrl = determineRedirectUrl();
+		String redirectUrl = FRONT_LOCAL_URL + "/login/oauth?accessToken=" + "Bearer " + newAccessToken;
 		log.debug("[Google OAuth2] 리다이렉션 URL: {}", redirectUrl);
 		response.sendRedirect(redirectUrl);
 	}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 구글 로그인 성공 시 accessToken을 임시로 URL 파라미터로 전달

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 불필요한 코드는 제거했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 없음
- 기타(Chores)
  - Google OAuth 로그인 완료 후 리디렉션 경로를 고정된 프런트엔드 주소(예: http://localhost:3000/login/oauth)로 업데이트했습니다.
  - 리디렉션 시 액세스 토큰을 쿼리 파라미터로 함께 전달하도록 변경했습니다.
  - 브라우저는 로그인 후 지정된 경로로 이동하며, 기존의 토큰 전달 방식(헤더 포함)은 유지됩니다.
  - 로컬 환경에서 로그인 흐름이 보다 일관되게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->